### PR TITLE
Feature/fix taxa tree

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict
       - id: debug-statements
@@ -10,7 +10,7 @@ repos:
       - id: isort
         additional_dependencies: [toml]
   - repo: https://github.com/psf/black
-    rev: "22.3.0"
+    rev: "22.8.0"
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8
@@ -23,6 +23,6 @@ repos:
   #   hooks:
   #     - id: mypy
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.31.1
+    rev: v0.32.2
     hooks:
     - id: markdownlint

--- a/safedata_validator/field.py
+++ b/safedata_validator/field.py
@@ -10,7 +10,7 @@ import datetime
 import os
 from itertools import groupby, islice
 from logging import CRITICAL, ERROR, INFO, WARNING
-from typing import List, Type, Union
+from typing import List, Optional, Type, Union
 
 import simplejson
 from dateutil import parser
@@ -132,7 +132,7 @@ class Dataset:
         Logging messages are used to report the progress of the validation process.
         These are always captured in an internal log (`logging.LOG`) but are also
         printed by default to the command line. The `console_log` argument can be used
-        to suppress console logging, when this command is being run programatically
+        to suppress console logging, when this command is being run programmatically
         rather than via the `safedata_validate` command line script.
 
         Args:
@@ -444,7 +444,7 @@ class Dataset:
 
 
 class DataWorksheet:
-    """Process the comtents of safedata_validator formatted data table.
+    """Process the contents of safedata_validator formatted data table.
 
     This class is used to load and check the formatting and content of a data table
     using the safedata_validator format. It requires the containing Dataset as an
@@ -956,7 +956,7 @@ class BaseField:
         dwsh: The DataWorksheet object in which the field is contained.
         taxa: The Taxa object for the Dataset or None.
         locations: The Locations object for the Dataset or None.
-        summary: The Summary objet for the Dataset or None.
+        summary: The Summary object for the Dataset or None.
         log_stack: A list of tuples containing logging messages to be emitted.
         n_rows: The number of rows of data in the field.
         n_na: The number of NA values in the field data.
@@ -984,7 +984,7 @@ class BaseField:
         self.meta = meta
         self.dwsh = dwsh
 
-        self.taxa = None
+        self.taxa: Optional[Taxa] = None
         self.locations = None
         self.summary = None
 

--- a/safedata_validator/field.py
+++ b/safedata_validator/field.py
@@ -82,7 +82,7 @@ class Dataset:
         self.resources = resources
         self.summary = Summary(resources)
         self.taxa = Taxa(resources)
-        self.dataworksheets = []
+        self.dataworksheets: list[DataWorksheet] = []
         self.n_errors = 0
         self.passed = False
 

--- a/safedata_validator/resources.py
+++ b/safedata_validator/resources.py
@@ -182,6 +182,7 @@ class Resources:
             LOGGER.critical(f"No user config in {user_cfg_file}")
             LOGGER.critical(f"No site config in {site_cfg_file}")
             log_and_raise("No config files provided or found", RuntimeError)
+            return
 
         # Report resource config location and type
         msg = f"Configuring resources from {config_type}"

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -8,9 +8,9 @@ methods for loading the summary data from file.
 
 import datetime
 import re
-from typing import Union
+from typing import Optional, Union
 
-import requests
+import requests  # type: ignore
 from openpyxl.worksheet.worksheet import Worksheet
 
 from safedata_validator.extent import Extent
@@ -43,7 +43,7 @@ class Summary:
     methods check the information provided in the summary worksheet and populates the
     attributes of the class instance to pass that information to other components.
 
-    The methods are intended to try andget as much information as possible from the
+    The methods are intended to try and get as much information as possible from the
     Summary table: the instance attributes may therefore be set to None for missing
     metadata, so classes using Summary should handle None values.
 
@@ -216,12 +216,12 @@ class Summary:
             soft_bounds=resources.extents.longitudinal_soft_extent,
         )
         self.external_files = None
-        self.data_worksheets = []
+        self.data_worksheets: list[Worksheet] = []
 
-        self._rows = None
+        self._rows: Optional[dict] = None
         self._ncols = None
-        self.n_errors = None
-        self.valid_pid = None
+        self.n_errors: Optional[int] = None
+        self.valid_pid: Optional[list[int]] = None
         self.validate_doi = False
 
     @loggerinfo_push_pop("Checking Summary worksheet")
@@ -325,7 +325,7 @@ class Summary:
     def _read_block(
         self, field_desc: tuple, mandatory: bool, title: str, only_one: bool
     ) -> Union[None, list]:
-        """Read a block of fields from a summmary table.
+        """Read a block of fields from a summary table.
 
         This internal method takes a given block definition from the Summary class
         [fields][safedata_validator.summary.Summary.fields] attribute and returns a list

--- a/safedata_validator/taxa.py
+++ b/safedata_validator/taxa.py
@@ -40,6 +40,8 @@ from logging import Formatter
 from typing import Optional, Union
 
 import requests  # type: ignore
+from dominate import tags  # TEMP - DELETE LATER
+from dominate.util import raw  # TEMP - DELETE LATER
 from lxml import etree
 from openpyxl import worksheet
 
@@ -2786,9 +2788,9 @@ class Taxa:
         return self.gbif_taxa.taxon_names.intersection(self.ncbi_taxa.taxon_names)
 
 
-# TODO - Decide whether to delete this function
+# TODO - Fix multiple branch error
 def taxon_index_to_text(
-    taxon_index: list, html: bool = False, indent_width: int = 4
+    taxa: list[dict], html: bool = False, indent_width: int = 4
 ) -> str:
     """Render a GBIFTaxa instance as text or html.
 
@@ -2800,16 +2802,19 @@ def taxon_index_to_text(
         taxon_index: The taxon_index property of a GBIFTaxa or NCBITaxa instance.
         html: Render as html or text
         indent_width: The indentation width to use for successive taxonomic ranks.
+
+    Returns:
+        A `dominate.tags.div` object containing an HTML representation of the taxa.
     """
 
     lbr = "<br>" if html else "\n"
 
-    def indent(n, use_html=html):
+    def _indent(n, use_html=html):
 
         ind = "&ensp;" if use_html else " "
         return ind * indent_width * (n - 1)
 
-    def format_name(tx, use_html=html):
+    def _format_name(tx, use_html=html):
 
         # format the canonical name
         if tx[4] in ["genus", "species", "subspecies"]:
@@ -2825,55 +2830,170 @@ def taxon_index_to_text(
     # Container to hold the output
     html_out = StringIO()
 
-    # group by parent taxon id in position 2, substituting 0 for None
-    taxon_index.sort(key=lambda x: x[2] or 0)
-    grouped = {k: list(v) for k, v in groupby(taxon_index, lambda x: x[2])}
+    # group by parent taxon, substituting 0 for None
+    taxa.sort(key=lambda x: x["gbif_parent_id"] or 0)
+    grouped = {k: list(v) for k, v in groupby(taxa, lambda x: x["gbif_parent_id"])}
 
     # start the stack with the kingdoms - these taxa will have None as a parent
-    stack = [{"current": grouped[None][0], "next": grouped[None][1:]}]
+    stack = [({"current": grouped[None][0]}, {"next": grouped[None][1:]})]
 
     while stack:
 
         # Handle the current top of the stack: format the canonical name
-        current = stack[-1]["current"]
-        canon_name = format_name(current)
+        current = stack[-1][0]["current"]
+        canon_name = _format_name(current)
 
         # Look for a non-None entry in next that shares the same worksheet name
-        next_ws_names = [tx[0] for tx in stack[-1]["next"] if tx[0] is not None]
+        next_ws_names = [
+            tx["worksheet_name"]
+            for tx in stack[-1][1]["next"]
+            if tx["worksheet_name"] is not None
+        ]
 
-        if current[0] in next_ws_names:
+        if current["worksheet_name"] in next_ws_names:
             # pop out the matching entry and find which is 'accepted'
-            name_pair = stack[-1]["next"].pop(next_ws_names.index(current[0]))
-            if current[5] == "accepted":
-                as_name = format_name(name_pair)
-                as_status = name_pair[5]
+            name_pair = stack[-1][1]["next"].pop(
+                next_ws_names.index(current["worksheet_name"])
+            )
+            if current["gbif_status"] == "accepted":
+                as_name = _format_name(name_pair)
+                as_status = name_pair["gbif_status"]
             else:
                 as_name = canon_name
-                as_status = current[5]
-                canon_name = format_name(name_pair)
+                as_status = current["gbif_status"]
+                canon_name = _format_name(name_pair)
 
-            txt = f"{indent(len(stack))} {canon_name} (as {as_status}: {as_name}){lbr}"
+            txt = f"{_indent(len(stack))} {canon_name} (as {as_status}: {as_name}){lbr}"
         else:
-            txt = f"{indent(len(stack))} {canon_name}{lbr}"
+            txt = f"{_indent(len(stack))} {canon_name}{lbr}"
 
         html_out.write(txt)
 
         # Is this taxon a parent for other taxa - if so add that taxon to the top of
         # the stack, otherwise start looking for a next taxon to push onto the stack.
         # If there is none at the top, pop and look down.
-        parent_id = current[1]
+        parent_id = current["gbif_taxon_id"]
         if parent_id in grouped:
             stack.append(
-                {"current": grouped[parent_id][0], "next": grouped[parent_id][1:]}
+                ({"current": grouped[parent_id][0]}, {"next": grouped[parent_id][1:]})
             )
         else:
             while stack:
                 push = stack.pop()
-                if push["next"]:
-                    stack.append({"current": push["next"][0], "next": push["next"][1:]})
+                if push[1]["next"]:
+                    stack.append(
+                        ({"current": push[1]["next"][0]}, {"next": push[1]["next"][1:]})
+                    )
                     break
 
     return html_out.getvalue()
+
+
+def ncbi_index_to_html(taxa: list[dict]) -> tags.div:
+    """Generate an HTML formatted taxon list for an NCBI index.
+
+    Takes a taxon index - a list containing taxon dictionaries - and converts into
+    an dominate.tags.div() object containing a simple HTML representation of the
+    taxonomy. The representation uses indentation to show taxonomic depth. This function
+    differs from `taxon_index_to_html` in that it works for NCBI indices rather than
+    GBIF.
+
+    Arguments:
+        taxa: A list of taxon dictionaries containing the taxa for a dataset.
+
+    Returns:
+        A `dominate.tags.div` object containing an HTML representation of the taxa.
+    """
+
+    def _indent(n):
+
+        return raw("&ensp;-&ensp;" * n)
+
+    def _format_name(tx):
+
+        # format the canonical name
+        if tx["ncbi_status"] == "user":
+            if tx["taxon_rank"] in BACKBONE_RANKS_EX:
+                return f"[{tx['taxon_name']}]"
+            else:
+                return f"[{tx['taxon_name']}]  (non-backbone rank: {tx['taxon_rank']})"
+        else:
+            if tx["taxon_rank"] in ["genus", "species", "subspecies"]:
+                return tags.i(tx["taxon_name"])
+            elif tx["taxon_rank"] not in BACKBONE_RANKS_EX:
+                return f"{tx['taxon_name']} (non-backbone rank: {tx['taxon_rank']})"
+            else:
+                return tx["taxon_name"]
+
+    # Container to hold the output
+    html = tags.div()
+
+    # group by parent taxon, substituting 0 for None
+    taxa.sort(key=lambda x: x["ncbi_parent_id"] or 0)
+    grouped = {k: list(v) for k, v in groupby(taxa, lambda x: x["ncbi_parent_id"])}
+
+    # start the stack with the superkingdoms - these taxa will have None as a parent
+    stack = [({"current": grouped[None][0]}, {"next": grouped[None][1:]})]
+
+    while stack:
+
+        # Handle the current top of the stack: format the canonical name
+        current = stack[-1][0]["current"]
+        canon_name = _format_name(current)
+
+        # Look for a non-None entry in next that shares the same worksheet name
+        next_ws_names = [
+            tx["worksheet_name"]
+            for tx in stack[-1][1]["next"]
+            if tx["worksheet_name"] is not None
+        ]
+
+        if current["worksheet_name"] in next_ws_names:
+            # pop out the matching entry and find which is 'accepted'
+            name_pair = stack[-1][1]["next"].pop(
+                next_ws_names.index(current["worksheet_name"])
+            )
+            if current["ncbi_status"] == "accepted":
+                as_name = _format_name(name_pair)
+                as_status = name_pair["ncbi_status"]
+            else:
+                as_name = canon_name
+                as_status = current["ncbi_status"]
+                canon_name = _format_name(name_pair)
+
+            txt = [
+                _indent(len(stack)),
+                canon_name,
+                " (",
+                as_status,
+                " from: ",
+                as_name,
+                ")",
+                tags.br(),
+            ]
+        else:
+            txt = [_indent(len(stack)), canon_name, tags.br()]
+
+        html += txt
+
+        # Is this taxon a parent for other taxa - if so add that taxon to the top of
+        # the stack, otherwise start looking for a next taxon to push onto the stack.
+        # If there is none at the top, pop and look down.
+        parent_id = current["ncbi_taxon_id"]
+        if parent_id in grouped:
+            stack.append(
+                ({"current": grouped[parent_id][0]}, {"next": grouped[parent_id][1:]})
+            )
+        else:
+            while stack:
+                push = stack.pop()
+                if push[1]["next"]:
+                    stack.append(
+                        ({"current": push[1]["next"][0]}, {"next": push[1]["next"][1:]})
+                    )
+                    break
+
+    return html
 
 
 def taxa_strip(name: str, rank: str) -> tuple[str, bool]:

--- a/safedata_validator/taxa.py
+++ b/safedata_validator/taxa.py
@@ -2791,7 +2791,6 @@ class Taxa:
         return self.gbif_taxa.taxon_names.intersection(self.ncbi_taxa.taxon_names)
 
 
-# TODO - Fix multiple branch error
 def taxon_index_to_text(
     taxa: list[dict], html: bool = False, indent_width: int = 4
 ) -> Union[str, tags.div]:
@@ -2838,7 +2837,8 @@ def taxon_index_to_text(
         html_out = StringIO()
 
     # group by parent taxon, substituting 0 for None
-    taxa.sort(key=lambda x: x["gbif_parent_id"] or 0)
+    # secondary order is then alphabetic based on taxon name
+    taxa.sort(key=lambda x: (x["gbif_parent_id"] or 0, x["taxon_name"]))
 
     # Preallocate container to store identity of surplus taxa
     surp_tx_ids = []
@@ -2874,7 +2874,7 @@ def taxon_index_to_text(
     for index in sorted(surp_tx_ids, reverse=True):
         del taxa[index]
 
-    # TODO - ALPHABETISE
+    # group taxa by their parent id
     grouped = {k: list(v) for k, v in groupby(taxa, lambda x: x["gbif_parent_id"])}
 
     # start the stack with the kingdoms - these taxa will have None as a parent
@@ -3009,7 +3009,8 @@ def ncbi_index_to_text(
         html_out = StringIO()
 
     # group by parent taxon, substituting 0 for None
-    taxa.sort(key=lambda x: x["ncbi_parent_id"] or 0)
+    # secondary order is then alphabetic based on taxon name
+    taxa.sort(key=lambda x: (x["ncbi_parent_id"] or 0, x["taxon_name"]))
 
     # Preallocate container to store identity of surplus taxa
     surp_tx_ids = []

--- a/safedata_validator/taxa.py
+++ b/safedata_validator/taxa.py
@@ -2799,12 +2799,12 @@ def taxon_index_to_text(
     dataset. Taxonomic ranks are indented to render a nested hierarchy.
 
     Args:
-        taxon_index: The taxon_index property of a GBIFTaxa or NCBITaxa instance.
-        html: Render as html or text
+        taxa: A list of taxon dictionaries containing the taxa for a dataset.
+        html: Render as html or text.
         indent_width: The indentation width to use for successive taxonomic ranks.
 
     Returns:
-        A `dominate.tags.div` object containing an HTML representation of the taxa.
+        A string containing either a HTML or text representation of the taxa tree.
     """
 
     lbr = "<br>" if html else "\n"

--- a/safedata_validator/taxa.py
+++ b/safedata_validator/taxa.py
@@ -37,9 +37,6 @@ from collections import Counter
 from io import StringIO
 from itertools import compress, groupby
 from logging import Formatter
-from tarfile import LENGTH_PREFIX
-from tkinter import INSERT
-from types import NoneType
 from typing import Optional, Union
 
 import requests  # type: ignore

--- a/safedata_validator/taxa.py
+++ b/safedata_validator/taxa.py
@@ -1665,7 +1665,7 @@ class GBIFTaxa:
         self.taxon_names: set[str] = set()
         self.parents: dict[tuple, GBIFTaxon] = dict()
         self.hierarchy: set[list] = set()
-        self.n_errors = None
+        self.n_errors: Optional[int] = None
         self.taxon_names_used: set[str] = set()
 
         # Get a validator instance
@@ -2282,7 +2282,7 @@ class NCBITaxa:
         self.taxon_index: list[list] = []
         self.taxon_names: set[str] = set()
         self.hierarchy: set[tuple] = set()
-        self.n_errors = None
+        self.n_errors: Optional[int] = None
 
         # Get a validator instance
         self.validator: Union[LocalNCBIValidator, RemoteNCBIValidator]

--- a/safedata_validator/zenodo.py
+++ b/safedata_validator/zenodo.py
@@ -50,7 +50,7 @@ from safedata_validator.logger import FORMATTER, LOGGER
 from safedata_validator.resources import Resources
 from safedata_validator.taxa import (
     BACKBONE_RANKS_EX,
-    ncbi_index_to_html,
+    ncbi_index_to_text,
     taxon_index_to_text,
 )
 
@@ -815,7 +815,7 @@ def dataset_description(
             tags.br(),
             " All taxon names are validated against the NCBI taxonomy database."
             f"{ncbi_text}",
-            ncbi_index_to_html(ncbi_taxon_index),
+            ncbi_index_to_text(ncbi_taxon_index, True),
         )
     elif ncbi_taxon_index and gbif_taxon_index:
         desc += tags.p(
@@ -823,7 +823,7 @@ def dataset_description(
             tags.br(),
             tags.br(),
             f"{ncbi_text}",
-            ncbi_index_to_html(ncbi_taxon_index),
+            ncbi_index_to_text(ncbi_taxon_index, True),
         )
 
     if render:

--- a/safedata_validator/zenodo.py
+++ b/safedata_validator/zenodo.py
@@ -48,7 +48,11 @@ from tqdm.utils import CallbackIOWrapper
 
 from safedata_validator.logger import FORMATTER, LOGGER
 from safedata_validator.resources import Resources
-from safedata_validator.taxa import BACKBONE_RANKS_EX
+from safedata_validator.taxa import (
+    BACKBONE_RANKS_EX,
+    ncbi_index_to_html,
+    taxon_index_to_text,
+)
 
 # Constant definition of zenodo action function response type
 ZenodoFunctionResponseType = tuple[Union[dict, None], Union[str, None]]
@@ -573,213 +577,6 @@ Dataset description generation (HTML and GEMINI XML)
 """
 
 
-# TODO - Fix multiple branch error
-def taxon_index_to_html(taxa: list[dict]) -> tags.div:
-    """Generate an HTML formatted taxon list.
-
-    Takes a taxon index - a list containing taxon dictionaries - and converts into
-    an dominate.tags.div() object containing a simple HTML representation of the
-    taxonomy. The representation uses indentation to show taxonomic depth.
-
-    Arguments:
-        taxa: A list of taxon dictionaries containing the taxa for a dataset.
-
-    Returns:
-        A `dominate.tags.div` object containing an HTML representation of the taxa.
-    """
-
-    def _indent(n):
-
-        return raw("&ensp;-&ensp;" * n)
-
-    def _format_name(tx):
-
-        # format the canonical name
-        if tx["taxon_rank"] in ["genus", "species", "subspecies"]:
-            return tags.i(tx["taxon_name"])
-        elif tx["taxon_rank"] in ["morphospecies", "functional group"]:
-            return f"[{tx['taxon_name']}]"
-        else:
-            return tx["taxon_name"]
-
-    # Container to hold the output
-    html = tags.div()
-
-    # group by parent taxon, substituting 0 for None
-    taxa.sort(key=lambda x: x["gbif_parent_id"] or 0)
-    grouped = {k: list(v) for k, v in groupby(taxa, lambda x: x["gbif_parent_id"])}
-
-    # start the stack with the kingdoms - these taxa will have None as a parent
-    stack = [({"current": grouped[None][0]}, {"next": grouped[None][1:]})]
-
-    while stack:
-
-        # Handle the current top of the stack: format the canonical name
-        current = stack[-1][0]["current"]
-        canon_name = _format_name(current)
-
-        # Look for a non-None entry in next that shares the same worksheet name
-        next_ws_names = [
-            tx["worksheet_name"]
-            for tx in stack[-1][1]["next"]
-            if tx["worksheet_name"] is not None
-        ]
-
-        if current["worksheet_name"] in next_ws_names:
-            # pop out the matching entry and find which is 'accepted'
-            name_pair = stack[-1][1]["next"].pop(
-                next_ws_names.index(current["worksheet_name"])
-            )
-            if current["gbif_status"] == "accepted":
-                as_name = _format_name(name_pair)
-                as_status = name_pair["gbif_status"]
-            else:
-                as_name = canon_name
-                as_status = current["gbif_status"]
-                canon_name = _format_name(name_pair)
-
-            txt = [
-                _indent(len(stack)),
-                canon_name,
-                " (as ",
-                as_status,
-                ": ",
-                as_name,
-                ")",
-                tags.br(),
-            ]
-        else:
-            txt = [_indent(len(stack)), canon_name, tags.br()]
-
-        html += txt
-
-        # Is this taxon a parent for other taxa - if so add that taxon to the top of
-        # the stack, otherwise start looking for a next taxon to push onto the stack.
-        # If there is none at the top, pop and look down.
-        parent_id = current["gbif_taxon_id"]
-        if parent_id in grouped:
-            stack.append(
-                ({"current": grouped[parent_id][0]}, {"next": grouped[parent_id][1:]})
-            )
-        else:
-            while stack:
-                push = stack.pop()
-                if push[1]["next"]:
-                    stack.append(
-                        ({"current": push[1]["next"][0]}, {"next": push[1]["next"][1:]})
-                    )
-                    break
-
-    return html
-
-
-def ncbi_index_to_html(taxa: list[dict]) -> tags.div:
-    """Generate an HTML formatted taxon list for an NCBI index.
-
-    Takes a taxon index - a list containing taxon dictionaries - and converts into
-    an dominate.tags.div() object containing a simple HTML representation of the
-    taxonomy. The representation uses indentation to show taxonomic depth. This function
-    differs from `taxon_index_to_html` in that it works for NCBI indices rather than
-    GBIF.
-
-    Arguments:
-        taxa: A list of taxon dictionaries containing the taxa for a dataset.
-
-    Returns:
-        A `dominate.tags.div` object containing an HTML representation of the taxa.
-    """
-
-    def _indent(n):
-
-        return raw("&ensp;-&ensp;" * n)
-
-    def _format_name(tx):
-
-        # format the canonical name
-        if tx["ncbi_status"] == "user":
-            if tx["taxon_rank"] in BACKBONE_RANKS_EX:
-                return f"[{tx['taxon_name']}]"
-            else:
-                return f"[{tx['taxon_name']}]  (non-backbone rank: {tx['taxon_rank']})"
-        else:
-            if tx["taxon_rank"] in ["genus", "species", "subspecies"]:
-                return tags.i(tx["taxon_name"])
-            elif tx["taxon_rank"] not in BACKBONE_RANKS_EX:
-                return f"{tx['taxon_name']} (non-backbone rank: {tx['taxon_rank']})"
-            else:
-                return tx["taxon_name"]
-
-    # Container to hold the output
-    html = tags.div()
-
-    # group by parent taxon, substituting 0 for None
-    taxa.sort(key=lambda x: x["ncbi_parent_id"] or 0)
-    grouped = {k: list(v) for k, v in groupby(taxa, lambda x: x["ncbi_parent_id"])}
-
-    # start the stack with the superkingdoms - these taxa will have None as a parent
-    stack = [({"current": grouped[None][0]}, {"next": grouped[None][1:]})]
-
-    while stack:
-
-        # Handle the current top of the stack: format the canonical name
-        current = stack[-1][0]["current"]
-        canon_name = _format_name(current)
-
-        # Look for a non-None entry in next that shares the same worksheet name
-        next_ws_names = [
-            tx["worksheet_name"]
-            for tx in stack[-1][1]["next"]
-            if tx["worksheet_name"] is not None
-        ]
-
-        if current["worksheet_name"] in next_ws_names:
-            # pop out the matching entry and find which is 'accepted'
-            name_pair = stack[-1][1]["next"].pop(
-                next_ws_names.index(current["worksheet_name"])
-            )
-            if current["ncbi_status"] == "accepted":
-                as_name = _format_name(name_pair)
-                as_status = name_pair["ncbi_status"]
-            else:
-                as_name = canon_name
-                as_status = current["ncbi_status"]
-                canon_name = _format_name(name_pair)
-
-            txt = [
-                _indent(len(stack)),
-                canon_name,
-                " (",
-                as_status,
-                " from: ",
-                as_name,
-                ")",
-                tags.br(),
-            ]
-        else:
-            txt = [_indent(len(stack)), canon_name, tags.br()]
-
-        html += txt
-
-        # Is this taxon a parent for other taxa - if so add that taxon to the top of
-        # the stack, otherwise start looking for a next taxon to push onto the stack.
-        # If there is none at the top, pop and look down.
-        parent_id = current["ncbi_taxon_id"]
-        if parent_id in grouped:
-            stack.append(
-                ({"current": grouped[parent_id][0]}, {"next": grouped[parent_id][1:]})
-            )
-        else:
-            while stack:
-                push = stack.pop()
-                if push[1]["next"]:
-                    stack.append(
-                        ({"current": push[1]["next"][0]}, {"next": push[1]["next"][1:]})
-                    )
-                    break
-
-    return html
-
-
 def dataset_description(
     metadata: dict,
     zenodo: dict,
@@ -994,7 +791,7 @@ def dataset_description(
             tags.br(),
             f" All taxon names are validated against the GBIF backbone taxonomy."
             f"{gbif_text}",
-            taxon_index_to_html(gbif_taxon_index),
+            taxon_index_to_text(gbif_taxon_index, True),
         )
     elif gbif_taxon_index and ncbi_taxon_index:
         desc += tags.p(
@@ -1008,7 +805,7 @@ def dataset_description(
             tags.br(),
             tags.br(),
             f"{gbif_text}",
-            taxon_index_to_html(gbif_taxon_index),
+            taxon_index_to_text(gbif_taxon_index, True),
         )
 
     # Similar handling used for the NCBI case

--- a/safedata_validator/zenodo.py
+++ b/safedata_validator/zenodo.py
@@ -48,11 +48,7 @@ from tqdm.utils import CallbackIOWrapper
 
 from safedata_validator.logger import FORMATTER, LOGGER
 from safedata_validator.resources import Resources
-from safedata_validator.taxa import (
-    BACKBONE_RANKS_EX,
-    ncbi_index_to_text,
-    taxon_index_to_text,
-)
+from safedata_validator.taxa import ncbi_index_to_text, taxon_index_to_text
 
 # Constant definition of zenodo action function response type
 ZenodoFunctionResponseType = tuple[Union[dict, None], Union[str, None]]


### PR DESCRIPTION
Moved the definition of the taxon index functions to `taxa.py` and extended them to allow the return of text rather than just html. Also fixes the duplicated taxa problem, by removing duplicated taxa from the index before the iterative tree building starts. In addition, the function now places the tree branches in alphabetic order. An example of the new taxa tree structure can be seen [here](https://sandbox.zenodo.org/record/1103769#.Yx8KGy0w08Q).

This pull request fixes issues #15 and #18