### PR TITLE
Bug/taxa in descriptions

### DIFF
--- a/safedata_validator/taxa.py
+++ b/safedata_validator/taxa.py
@@ -2121,7 +2121,7 @@ def taxon_index_to_text(
                 else:
                     return f"_{tx['taxon_name']}_"
             elif tx["taxon_rank"] in ["morphospecies", "functional group"]:
-                return f"[{tx['taxon_name']}]"
+                return f"[{tx['worksheet_name']}, {tx['taxon_rank']}]"
             else:
                 return tx["taxon_name"]
 

--- a/safedata_validator/taxa.py
+++ b/safedata_validator/taxa.py
@@ -2084,42 +2084,68 @@ class Taxa:
 
 
 def taxon_index_to_text(
-    taxa: list[dict], html: bool = False, indent_width: int = 4
+    taxa: list[dict], html: bool = False, indent_width: int = 4, auth: str = "GBIF"
 ) -> Union[str, tags.div]:
     """Render a GBIFTaxa instance as text or html.
 
-    This function takes a taxon index from a GBIFTaxa instance and renders the contents
-    into either a text or html representation of the taxonomic hierarchy used in the
-    dataset. Taxonomic ranks are indented to render a nested hierarchy.
+    This function takes a taxon index and renders the contents into either a text or
+    html representation of the taxonomic hierarchy used in the dataset. Taxonomic ranks
+    are indented to render a nested hierarchy. The `auth` argument is used to set
+    whether the taxa are validated using GBIF or NCBI and this only affects the
+    formatting of the names in the representation.
 
     Args:
         taxa: A list of taxon dictionaries containing the taxa for a dataset.
         html: Render as html or text.
         indent_width: The indentation width to use for successive taxonomic ranks.
+        auth: The taxonomic authority that the taxa are taken from.
 
     Returns:
         Either a HTML or text representation of the taxa tree.
     """
 
-    def _indent(n, use_html=html):
+    def _indent(n: int, use_html: bool = html):
 
         if use_html:
             return raw("&ensp;-&ensp;" * n)
         else:
             return " " * indent_width * (n - 1)
 
-    def _format_name(tx, use_html=html):
+    def _format_name(tx: dict, use_html: bool = html, auth: str = "GBIF"):
 
-        # format the canonical name
-        if tx["taxon_rank"] in ["genus", "species", "subspecies"]:
-            if use_html:
-                return tags.i(tx["taxon_name"])
+        if auth == "GBIF":
+            # format the canonical name
+            if tx["taxon_rank"] in ["genus", "species", "subspecies"]:
+                if use_html:
+                    return tags.i(tx["taxon_name"])
+                else:
+                    return f"_{tx['taxon_name']}_"
+            elif tx["taxon_rank"] in ["morphospecies", "functional group"]:
+                return f"[{tx['taxon_name']}]"
             else:
-                return f"_{tx['taxon_name']}_"
-        elif tx["taxon_rank"] in ["morphospecies", "functional group"]:
-            return f"[{tx['taxon_name']}]"
+                return tx["taxon_name"]
+
+        elif auth == "NCBI":
+            # format the canonical name
+            if tx["taxon_status"] == "user":
+                if tx["taxon_rank"] in BACKBONE_RANKS_EX:
+                    return f"[{tx['taxon_name']}]"
+                else:
+                    return (
+                        f"[{tx['taxon_name']}]  (non-backbone rank: {tx['taxon_rank']})"
+                    )
+            else:
+                if tx["taxon_rank"] in ["genus", "species", "subspecies"]:
+                    if use_html:
+                        return tags.i(tx["taxon_name"])
+                    else:
+                        return f"_{tx['taxon_name']}_"
+                elif tx["taxon_rank"] not in BACKBONE_RANKS_EX:
+                    return f"{tx['taxon_name']} (non-backbone rank: {tx['taxon_rank']})"
+                else:
+                    return tx["taxon_name"]
         else:
-            return tx["taxon_name"]
+            raise ValueError(f"Unknown auth value: {auth}")
 
     # Container type depends on whether or not html output is required
     if html:
@@ -2130,17 +2156,17 @@ def taxon_index_to_text(
 
     # group by parent taxon, substituting 0 for None
     # secondary order is then alphabetic based on taxon name
-    taxa.sort(key=lambda x: (x["gbif_parent_id"] or 0, x["taxon_name"]))
+    taxa.sort(key=lambda x: (x["parent_id"] or 0, x["taxon_name"]))
 
     # Preallocate container to store identity of surplus taxa
     surp_tx_ids = []
     # Define keys that would match in unwanted repeated entries
     match_keys = [
-        "gbif_taxon_id",
-        "gbif_parent_id",
+        "taxon_id",
+        "parent_id",
         "taxon_name",
         "taxon_rank",
-        "gbif_status",
+        "taxon_status",
     ]
 
     # Loop over taxa to filter for repeated entries
@@ -2167,9 +2193,10 @@ def taxon_index_to_text(
         del taxa[index]
 
     # group taxa by their parent id
-    grouped = {k: list(v) for k, v in groupby(taxa, lambda x: x["gbif_parent_id"])}
+    grouped = {k: list(v) for k, v in groupby(taxa, lambda x: x["parent_id"])}
 
-    # start the stack with the kingdoms - these taxa will have None as a parent
+    # start the stack with root taxa, which will have None as a parent (kingdoms for
+    # GBIF and superkingdoms for NCBI)
     stack = [({"current": grouped[None][0]}, {"next": grouped[None][1:]})]
 
     while stack:
@@ -2190,12 +2217,12 @@ def taxon_index_to_text(
             name_pair = stack[-1][1]["next"].pop(
                 next_ws_names.index(current["worksheet_name"])
             )
-            if current["gbif_status"] == "accepted":
+            if current["taxon_status"] == "accepted":
                 as_name = _format_name(name_pair)
-                as_status = name_pair["gbif_status"]
+                as_status = name_pair["taxon_status"]
             else:
                 as_name = canon_name
-                as_status = current["gbif_status"]
+                as_status = current["taxon_status"]
                 canon_name = _format_name(name_pair)
 
             if html:
@@ -2227,178 +2254,7 @@ def taxon_index_to_text(
         # Is this taxon a parent for other taxa - if so add that taxon to the top of
         # the stack, otherwise start looking for a next taxon to push onto the stack.
         # If there is none at the top, pop and look down.
-        parent_id = current["gbif_taxon_id"]
-        if parent_id in grouped:
-            stack.append(
-                ({"current": grouped[parent_id][0]}, {"next": grouped[parent_id][1:]})
-            )
-        else:
-            while stack:
-                push = stack.pop()
-                if push[1]["next"]:
-                    stack.append(
-                        ({"current": push[1]["next"][0]}, {"next": push[1]["next"][1:]})
-                    )
-                    break
-
-    if html:
-        return html_out
-    else:
-        return html_out.getvalue()
-
-
-def ncbi_index_to_text(
-    taxa: list[dict], html: bool = False, indent_width: int = 4
-) -> Union[str, tags.div]:
-    """Render a NCBITaxa instance as text or html.
-
-    This function takes a taxon index from a NCBITaxa instance and renders the contents
-    into either a text or html representation of the taxonomic hierarchy used in the
-    dataset. Taxonomic ranks are indented to render a nested hierarchy. This function
-    differs from `taxon_index_to_html` in that it works for NCBI indices rather than
-    GBIF.
-
-    Args:
-        taxa: A list of taxon dictionaries containing the taxa for a dataset.
-        html: Render as html or text.
-        indent_width: The indentation width to use for successive taxonomic ranks.
-
-    Returns:
-        Either a HTML or text representation of the taxa tree.
-    """
-
-    def _indent(n, use_html=html):
-
-        if use_html:
-            return raw("&ensp;-&ensp;" * n)
-        else:
-            return " " * indent_width * (n - 1)
-
-    def _format_name(tx, use_html=html):
-
-        # format the canonical name
-        if tx["ncbi_status"] == "user":
-            if tx["taxon_rank"] in BACKBONE_RANKS_EX:
-                return f"[{tx['taxon_name']}]"
-            else:
-                return f"[{tx['taxon_name']}]  (non-backbone rank: {tx['taxon_rank']})"
-        else:
-            if tx["taxon_rank"] in ["genus", "species", "subspecies"]:
-                if use_html:
-                    return tags.i(tx["taxon_name"])
-                else:
-                    return f"_{tx['taxon_name']}_"
-            elif tx["taxon_rank"] not in BACKBONE_RANKS_EX:
-                return f"{tx['taxon_name']} (non-backbone rank: {tx['taxon_rank']})"
-            else:
-                return tx["taxon_name"]
-
-    # Container type depends on whether or not html output is required
-    if html:
-        # Container to hold the output
-        html_out = tags.div()
-    else:
-        html_out = StringIO()
-
-    # group by parent taxon, substituting 0 for None
-    # secondary order is then alphabetic based on taxon name
-    taxa.sort(key=lambda x: (x["ncbi_parent_id"] or 0, x["taxon_name"]))
-
-    # Preallocate container to store identity of surplus taxa
-    surp_tx_ids = []
-    # Define keys that would match in unwanted repeated entries
-    match_keys = [
-        "ncbi_taxon_id",
-        "ncbi_parent_id",
-        "taxon_name",
-        "taxon_rank",
-        "ncbi_status",
-    ]
-
-    # Loop over taxa to filter for repeated entries
-    for idx, taxon in enumerate(taxa):
-        # Identify elements in taxa where all 5 of the desired keys match
-        matches = list(
-            map(
-                lambda x: x == 5,
-                [sum([taxon[k] == item[k] for k in match_keys]) for item in taxa],
-            )
-        )
-        if sum(matches) > 1:
-            # Generate reduced list of matching taxa
-            taxa_mtch = list(compress(taxa, matches))
-            ws_names = [item["worksheet_name"] for item in taxa_mtch]
-            # Find first non-None worksheet names
-            first_nm = next(name for name in ws_names if name is not None)
-            # If it doesn't match worksheet name of taxon, add index to be deleted
-            if first_nm != taxon["worksheet_name"]:
-                surp_tx_ids.append(idx)
-
-    # Delete taxa that are superfluous by index
-    for index in sorted(surp_tx_ids, reverse=True):
-        del taxa[index]
-
-    grouped = {k: list(v) for k, v in groupby(taxa, lambda x: x["ncbi_parent_id"])}
-
-    # start the stack with the superkingdoms - these taxa will have None as a parent
-    stack = [({"current": grouped[None][0]}, {"next": grouped[None][1:]})]
-
-    while stack:
-
-        # Handle the current top of the stack: format the canonical name
-        current = stack[-1][0]["current"]
-        canon_name = _format_name(current)
-
-        # Look for a non-None entry in next that shares the same worksheet name
-        next_ws_names = [
-            tx["worksheet_name"]
-            for tx in stack[-1][1]["next"]
-            if tx["worksheet_name"] is not None
-        ]
-
-        if current["worksheet_name"] in next_ws_names:
-            # pop out the matching entry and find which is 'accepted'
-            name_pair = stack[-1][1]["next"].pop(
-                next_ws_names.index(current["worksheet_name"])
-            )
-            if current["ncbi_status"] == "accepted":
-                as_name = _format_name(name_pair)
-                as_status = name_pair["ncbi_status"]
-            else:
-                as_name = canon_name
-                as_status = current["ncbi_status"]
-                canon_name = _format_name(name_pair)
-
-            if html:
-                html_txt = [
-                    _indent(len(stack)),
-                    canon_name,
-                    " (as ",
-                    as_status,
-                    ": ",
-                    as_name,
-                    ")",
-                    tags.br(),
-                ]
-            else:
-                txt = (
-                    f"{_indent(len(stack))} {canon_name} (as {as_status}: {as_name})\n"
-                )
-        else:
-            if html:
-                html_txt = [_indent(len(stack)), canon_name, tags.br()]
-            else:
-                txt = f"{_indent(len(stack))} {canon_name}\n"
-
-        if html:
-            html_out += html_txt
-        else:
-            html_out.write(txt)
-
-        # Is this taxon a parent for other taxa - if so add that taxon to the top of
-        # the stack, otherwise start looking for a next taxon to push onto the stack.
-        # If there is none at the top, pop and look down.
-        parent_id = current["ncbi_taxon_id"]
+        parent_id = current["taxon_id"]
         if parent_id in grouped:
             stack.append(
                 ({"current": grouped[parent_id][0]}, {"next": grouped[parent_id][1:]})

--- a/safedata_validator/zenodo.py
+++ b/safedata_validator/zenodo.py
@@ -565,7 +565,7 @@ def post_metadata(
     )
 
     # trap errors in uploading metadata and tidy up
-    if mtd.status_code != 200:
+    if mtd.status_code != 201:
         return None, mtd.content
     else:
         return mtd.json(), None


### PR DESCRIPTION
This PR:

* Merges `ncbi_index_to_text` and `taxon_index_to_text` to take advantage of the synchronised taxon index tags to remove duplicated code. 
* The remaining `taxon_index_to_text` has an `auth` argument to switch between the different taxon name formatting rules for GBIF vs NCBI.
* Fixes #39 resulting from the changed taxon index tags.

An example of the outputs of the function for GBIF and NCBI can be seen here: https://sandbox.zenodo.org/record/1143772 