### PR TITLE
Fixes to a couple of documentation problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # The safedata_validator package
 
-This package provides methods to validate XLSX files containing formatted data and metadata using the SAFE Project data format.
+This package provides methods to validate XLSX files containing formatted data and
+metadata using the SAFE Project data format.
 
 See the main documentation for a detailed description and usage:
 
@@ -10,25 +11,52 @@ The rest of this document describes the project development and building structu
 
 ## Development notes
 
-
 ### Installing the development version
 
-Testing the command line interface requires the package to be installed, but this is conveniently done in 'editable' mode, where it is always looking at the current state of the repo directory.
+This package makes use of the `python` dependency manager
+[`poetry`](https://python-poetry.org). This means that the package and all required
+dependencies can be installed with a single command.
 
 ```bash
-pip install -e .
+poetry install
 ```
 
+This installed package is 'editable', i.e. it changes with the current state of the repo
+directory. The package is installed as part of a virtual environment, so can only be
+used when the relevant environment is active. This environment can be activated with a
+single `poetry` command.
+
+```bash
+poetry shell
+```
 
 ### Testing
 
-At present, the package is tested by running `safedata_validate` to check against a set of valid and bad input XLSX files. The code will move towards using the `pytest` framework, but at the moment is not structured to do this well. 
+Testing for this package makes use of the `pytest` framework. When new functions are
+added to this package unit tests for them must also be added. These operate as a check
+that functions still operate in the manner they were originally designed to. Either all
+unit tests can be run locally.
 
-Although the package is registered with Travis CI, at the moment, there is no testing to meaningfully fail.
+```bash
+pytest
+```
+
+Or a specific testing file can be run.
+
+```bash
+pytest test/test_specific_module.py
+```
+
+These unit tests are also run as part of our continuous integration workflow, which runs
+whenever commits are made to this repository and for all pull requests.
 
 ### Releasing a new version
 
-The repository uses the `git flow` framework for releasing versions. When the `develop` branch contains a version of the code to be released as a new version, `git flow release start x.y.z` is used to start a release branch. When that has passed testing, the command `git flow release finish x.y.z` creates a new tagged version on the `master` branch. 
+The repository uses the `git flow` framework for releasing versions. When the `develop`
+branch contains a version of the code to be released as a new version, `git flow release
+start x.y.z` is used to start a release branch. When that has passed testing, the
+command `git flow release finish x.y.z` creates a new tagged version on the `master`
+branch.
 
 Note that the `master` branch should _only_ be used for new releases.
 
@@ -39,19 +67,25 @@ To publish a new version, first create the source distribution and a binary.
 python setup.py sdist bdist_wheel
 ```
 
-If the distribution is to be tested locally, then the following command can be used to install the source distribution:
+If the distribution is to be tested locally, then the following command can be used to
+install the source distribution:
 
 ```bash
 pip install safedata_validator --no-cache-dir --no-index --find-links dist/safedata_validator-x.y.z.tar.gz
 ```
 
-The `--no-index` and `--find-links` options stop `pip` from using the web package index and point to the local distribution. The `--no-cache-dir` is vital as `pip` will cache the installed package (probably in `/tmp/`) and *unless the version number changes* will just keep using that cache. So, in development, this flag is needed to keep `pip` using the actual local distribution and **not** the outdated cached version.
-
+The `--no-index` and `--find-links` options stop `pip` from using the web package index
+and point to the local distribution. The `--no-cache-dir` is vital as `pip` will cache
+the installed package (probably in `/tmp/`) and _unless the version number changes_ will
+just keep using that cache. So, in development, this flag is needed to keep `pip` using
+the actual local distribution and **not** the outdated cached version.
 
 ### Publishing a new version
 
-Versions are published to PyPi using `twine`.  As a first step, the new package is published to the PyPi **test** site, giving a chance to check the package upload before committing it to the live PyPi archive.
- 
+Versions are published to PyPi using `twine`.  As a first step, the new package is
+published to the PyPi **test** site, giving a chance to check the package upload before
+committing it to the live PyPi archive.
+
 ```bash
 # Install twine if you don't have it
 pip install twine
@@ -62,4 +96,3 @@ twine upload -r testpypi dist/safedata_validator-x.y.z*
 # Upload to the real PyPi site
 twine upload -r pypi dist/safedata_validator-x.y.z*
 ```
-

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -1,8 +1,9 @@
 # Configuring the `safedata_validator` package
 
-The `safedata_validator` package needs to be configured to use specific
-resources for data validation. This is done using a configuration file in the
-[INI file format](https://en.wikipedia.org/wiki/INI_file).
+The `safedata_validator` package needs to be configured to use specific resources for
+data validation. This is done using a configuration file in the [INI file
+format](https://en.wikipedia.org/wiki/INI_file). This configuration file **must** always
+be included regardless of what the package is being configured to do.
 
 ## Configuration file format
 
@@ -101,12 +102,14 @@ published that updates the location data to use the gazetteer locations directly
 ### GBIF database
 
 The `gbif_database` entry contains the path to the required local copy of the GBIF
-backbone database ([see here](build_local_gbif.md)).
+backbone database ([see here](build_local_gbif.md)). This database **must** be included
+even when no GBIF taxa are included.
 
 ### NCBI database
 
 The `ncbi_database` entry contains the path to the required local copy of the NCBI
-database, ([see here](build_local_ncbi.md)).
+database, ([see here](build_local_ncbi.md)). This database **must** be included even
+when no NCBI taxa are included.
 
 ### Extents
 

--- a/safedata_validator/logger.py
+++ b/safedata_validator/logger.py
@@ -25,7 +25,7 @@ when a new Dataset is being validated.
 import logging
 from functools import wraps
 from io import StringIO
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from typing_extensions import Type
 
@@ -111,7 +111,7 @@ class IndentFormatter(logging.Formatter):
     def __init__(
         self,
         fmt: str = "%(levelcode)s %(message)s",
-        datefmt: str = None,
+        datefmt: Optional[str] = None,
         indent: str = "    ",
     ) -> None:
 
@@ -213,7 +213,9 @@ LOGGER.addHandler(CONSOLE_HANDLER)
 #
 
 
-def log_and_raise(msg: str, exception: Type[Exception], extra: dict = None) -> None:
+def log_and_raise(
+    msg: str, exception: Type[Exception], extra: Optional[dict] = None
+) -> None:
     """Emit a critical error message and raise an Exception.
 
     This convenience function adds a critical level message to the logger and


### PR DESCRIPTION
Added a few lines to the configuration section of the docs emphasising that a config file is always needed, and that both local taxonomy databases must always exist. Also updated the `README` to talk about developer package installation via `poetry` and to talk a bit about `pytest` and unit testing.

As a bonus I resolved a couple of things `mypy` was complaining about in `logger.py`

Fixes #33 
Fixes #34 