### PR TITLE
Feature/cleaning for 300

### DIFF
--- a/safedata_validator/field.py
+++ b/safedata_validator/field.py
@@ -436,8 +436,8 @@ class Dataset:
             "total": self.n_errors,
             "summary": self.summary.n_errors,
             "locations": self.locations.n_errors,
-            "gbif": self.taxa.gbif_taxa.n_errors or 0,
-            "ncbi": self.taxa.ncbi_taxa.n_errors or 0,
+            "gbif": self.taxa.gbif_taxa.n_errors,
+            "ncbi": self.taxa.ncbi_taxa.n_errors,
             "data": [(d.name, d.n_errors) for d in self.dataworksheets],
         }
 

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -215,7 +215,7 @@ class Summary:
 
         self._rows: Optional[dict] = None
         self._ncols = None
-        self.n_errors: Optional[int] = None
+        self.n_errors: int = 0
         self.valid_pid: Optional[list[int]] = None
         self.validate_doi = False
 

--- a/safedata_validator/taxa.py
+++ b/safedata_validator/taxa.py
@@ -970,7 +970,7 @@ class GBIFTaxa:
         self.taxon_names: set[str] = set()
         self.parents: dict[tuple, GBIFTaxon] = dict()
         self.hierarchy: set[list] = set()
-        self.n_errors: Optional[int] = None
+        self.n_errors: int = 0
         self.taxon_names_used: set[str] = set()
 
         # Get the validator instance
@@ -1583,7 +1583,7 @@ class NCBITaxa:
         self.taxon_index: list[list] = []
         self.taxon_names: set[str] = set()
         self.hierarchy: set[tuple] = set()
-        self.n_errors: Optional[int] = None
+        self.n_errors: int = 0
 
         # Get the validator instance
         self.validator = NCBIValidator(resources)

--- a/safedata_validator/taxondb.py
+++ b/safedata_validator/taxondb.py
@@ -79,7 +79,7 @@ def download_gbif_backbone(outdir: str, timestamp: Optional[str] = None) -> dict
 
     url = f"https://hosted-datasets.gbif.org/datasets/backbone/{timestamp}/"
 
-    timestamp_head = requests.head(url + "simple.txt.gz")
+    timestamp_head = requests.head(url)
 
     if not timestamp_head.ok:
         log_and_raise(
@@ -93,9 +93,9 @@ def download_gbif_backbone(outdir: str, timestamp: Optional[str] = None) -> dict
     backbone_head = requests.head(url + "backbone.txt.gz")
     deleted_head = requests.head(url + "simple-deleted.txt.gz")
 
-    if not simple_head.ok or not backbone_head.ok:
+    if not (simple_head.ok or backbone_head.ok):
         log_and_raise(
-            "Timestamp version does not provide simple.txt.gz backbone.",
+            "Timestamp version does not provide simple.txt.gz or backbone.txt.gz",
             ValueError,
         )
 
@@ -106,7 +106,7 @@ def download_gbif_backbone(outdir: str, timestamp: Optional[str] = None) -> dict
         ]
     elif backbone_head.ok:
         targets = [
-            ("simple", "backbone.txt.gz", int(simple_head.headers["Content-Length"]))
+            ("simple", "backbone.txt.gz", int(backbone_head.headers["Content-Length"]))
         ]
 
     if deleted_head.ok:


### PR DESCRIPTION
This PR fixes two minor things:

* Inconsistent use of initial `n_errors` values across worksheets: sometimes `self.n_errors: Optional[int] = None` and sometimes `self.n_errors: int = 0`. Moved to consistently use the second form.
* Updated `download_gbif_database` to pick up older `backbone.txt.gz` as well as current `simple.txt.gz`.