### PR TITLE
Feature/cleanup publication docs

### DIFF
--- a/docs/package_development.md
+++ b/docs/package_development.md
@@ -161,28 +161,6 @@ poetry publish -r testpypi
 poetry publish
 ```
 
-## PyPi
-
-To upload the new version to testpypi, checkout master and run
-
-```sh
-python setup.py sdist bdist_wheel
-```
-
-Remembering to change the version number, you can then create an account at pypi
-and testpypi and use `twine` to test:
-
-```sh
-twine upload -r testpypi dist/*1.2.8*
-```
-
-and then - once that seems to have gone ok - release the distribution for use
-via `pip`
-
-```sh
-twine upload dist/*1.2.7*
-```
-
 ## Documentation
 
 The package documentation is maintained using [MkDocs](https://www.mkdocs.org/)

--- a/docs/package_development.md
+++ b/docs/package_development.md
@@ -106,6 +106,7 @@ git push
 
 Note that the `master` branch should _only_ be used for new releases.
 
+TODO - UPDATE THIS TO MATCH CHANGES TO HOW WE TALK ABOUT PYPI VS TEST PYPI
 Before the package is published it must first be built, this can be achieved using
 `poetry`.
 
@@ -115,7 +116,9 @@ poetry build
 
 This produces both a `sdist` source distribution, and a `wheel` compiled package.
 
-## Publishing a new version
+## TODO - Think of better name
+
+TODO - REFRAME SECTION TO BE JUST ABOUT TEST PYPI
 
 Version publication to PyPi also occurs using `poetry`. Before the package can be
 uploaded an API token for PyPi must be configured.
@@ -182,3 +185,7 @@ In order to build and deploy the documentation.
   rebuild of the package documentation.
 * To build the documentation for specific branches you need to login to [Read the
   Docs](https://readthedocs.org). You can then build whichever branch you require.
+
+## TODO - Think of better name (again)
+
+TODO - Write a section here that details final publication procedure

--- a/docs/package_development.md
+++ b/docs/package_development.md
@@ -164,37 +164,35 @@ In order to build and deploy the documentation.
 * To build the documentation for specific branches you need to login to [Read the
   Docs](https://readthedocs.org). You can then build whichever branch you require.
 
-## TODO - Think of better name (again)
+## Final publication of new package version
 
-TODO - Write a section here that details final publication procedure
-
-TODO -  Copy and paste this stuff into the test version where relevant
-
-TODO - SOME OF THIS HAS BEEN MENTIONED IN AN ABOVE SECTION, CHANGE TO ADDRESS THAT
-Before the package can be uploaded an API token for PyPi must be configured.
+Once a `release` branch has passed all the tests and been merged into `master`, it
+should be published to [PyPi](https://pypi.org/). This allows users to install the new
+package version via `pip`. As with test PyPi, publication is handled by the `poetry`
+package manager. PyPi is automatically configured as the default upload repository, so
+in this case you only need to add an API token to the `poetry` configuration for `PyPi`.
 
 ```bash
 poetry config pypi-token.pypi my_api_token
 ```
 
-This token should be a **personal** API token for PyPi, these can be generated through
-[your PyPi account](https://pypi.org/account/login/). We use **personal** tokens rather
-than a project specific token as the standard setup method with `poetry` only allows one
-PyPi token to be saved. If necessary this issue can be circumvented by adding each
-project as a new repository
+As with the token for test PyPi, this token should be a **personal** API token, these
+can be generated through [your PyPi account](https://pypi.org/account/login/). We use
+**personal** tokens rather than a project specific token as the standard setup method
+with `poetry` only allows one PyPi token to be saved. If necessary this issue can be
+circumvented by adding each project as a new repository
 [see](https://python-poetry.org/docs/repositories/#publishable-repositories) (with PyPi
 remaining the repository published to) and then configuring this duplicate repository to
 use the project specific token. We are not using this approach at present as we feel it
-introduces unnecessary complexity. Your **personal** token will only allow you to
-publish new package versions if you are a maintainer. If you wish to upload a new
-package version you should therefore contact the current maintainers to request
-maintainer status.
+introduces unnecessary complexity.
+
+It should be noted that your **personal** token will only allow you to publish new
+package versions if you are a maintainer. If you wish to upload a new package version
+you should therefore contact the current maintainers to request maintainer status.
+
+Once `poetry` has been setup to allow publication of `safedata_validator` to PyPi, the
+new package version can then be published.
 
 ```bash
-# Build source dist and binary
-poetry build
-# Upload just the new versions to the Test PyPi site and check it out
-poetry publish -r testpypi
-# Upload to the real PyPi site
 poetry publish
 ```

--- a/docs/package_development.md
+++ b/docs/package_development.md
@@ -106,63 +106,41 @@ git push
 
 Note that the `master` branch should _only_ be used for new releases.
 
-TODO - UPDATE THIS TO MATCH CHANGES TO HOW WE TALK ABOUT PYPI VS TEST PYPI
-Before the package is published it must first be built, this can be achieved using
-`poetry`.
+## Uploading package releases to test PyPi
 
-```bash
-poetry build
-```
-
-This produces both a `sdist` source distribution, and a `wheel` compiled package.
-
-## TODO - Think of better name
-
-TODO - REFRAME SECTION TO BE JUST ABOUT TEST PYPI
-
-Version publication to PyPi also occurs using `poetry`. Before the package can be
-uploaded an API token for PyPi must be configured.
-
-```bash
-poetry config pypi-token.pypi my_api_token
-```
-
-This token should be a **personal** API token for PyPi, these can be generated through
-[your PyPi account](https://pypi.org/account/login/). We use **personal** tokens rather
-than a project specific token as the standard setup method with `poetry` only allows one
-PyPi token to be saved. If necessary this issue can be circumvented by adding each
-project as a new repository
-[see](https://python-poetry.org/docs/repositories/#publishable-repositories) (with PyPi
-remaining the repository published to) and then configuring this duplicate repository to
-use the project specific token. We are not using this approach at present as we feel it
-introduces unnecessary complexity. Your **personal** token will only allow you to
-publish new package versions if you are a maintainer. If you wish to upload a new
-package version you should therefore contact the current maintainers to request
-maintainer status.
-
-Before you publish a new package version, you should first publish to the PyPi **test**
-site, which provides the opportunity to check the package upload before committing it to
-the live PyPi archive. This requires that you configure a valid API access token for
-test PyPi. It is important to note that separate accounts are used for PyPi and test
-PyPi, so you the test PyPi token will be not be the same as your standard PyPi token.
+It can often be the case that a package that appears to build fine locally has errors
+that prevent it from uploading properly to PyPi. By first uploading to [test PyPi
+site](https://test.pypi.org/) these kind of errors can be caught without clogging up the
+real PyPi site with broken packages. Upload of new package versions occurs via `poetry`.
+This means that `poetry` must be configured to have access to the test PyPi. To do this,
+test PyPi must be added as a repository, and a valid API access token must be associated
+with the repository.
 
 ```bash
 poetry config repositories.testpypi https://test.pypi.org/legacy/
 poetry config pypi-token.testpypi my_test_api_token
 ```
 
-It is important to note that a test upload should **always** be done before the package
-is uploaded to PyPi. Thus, when access to both PyPi repositories has been configured,
-the publication procedure is as follows.
+This token should be a **personal** API token for PyPi, these can be generated through
+[your test PyPi account](https://test.pypi.org/account/login/). We are now setup to
+publish to test PyPi, but before the package is published it must first be built. This
+also done using `poetry`.
 
 ```bash
-# Build source dist and binary
 poetry build
-# Upload just the new versions to the Test PyPi site and check it out
-poetry publish -r testpypi
-# Upload to the real PyPi site
-poetry publish
 ```
+
+This produces both a `sdist` source distribution, and a `wheel` compiled package. These
+can then be published to test PyPi.
+
+```bash
+poetry publish -r testpypi
+```
+
+It is important to note that a test upload should **always** be done before the package
+is uploaded to PyPi. You should perform a test upload when the `release` branch is
+created. You should also perform another test upload whenever significant changes are
+made to the `release` branch.
 
 ## Documentation
 
@@ -189,3 +167,34 @@ In order to build and deploy the documentation.
 ## TODO - Think of better name (again)
 
 TODO - Write a section here that details final publication procedure
+
+TODO -  Copy and paste this stuff into the test version where relevant
+
+TODO - SOME OF THIS HAS BEEN MENTIONED IN AN ABOVE SECTION, CHANGE TO ADDRESS THAT
+Before the package can be uploaded an API token for PyPi must be configured.
+
+```bash
+poetry config pypi-token.pypi my_api_token
+```
+
+This token should be a **personal** API token for PyPi, these can be generated through
+[your PyPi account](https://pypi.org/account/login/). We use **personal** tokens rather
+than a project specific token as the standard setup method with `poetry` only allows one
+PyPi token to be saved. If necessary this issue can be circumvented by adding each
+project as a new repository
+[see](https://python-poetry.org/docs/repositories/#publishable-repositories) (with PyPi
+remaining the repository published to) and then configuring this duplicate repository to
+use the project specific token. We are not using this approach at present as we feel it
+introduces unnecessary complexity. Your **personal** token will only allow you to
+publish new package versions if you are a maintainer. If you wish to upload a new
+package version you should therefore contact the current maintainers to request
+maintainer status.
+
+```bash
+# Build source dist and binary
+poetry build
+# Upload just the new versions to the Test PyPi site and check it out
+poetry publish -r testpypi
+# Upload to the real PyPi site
+poetry publish
+```


### PR DESCRIPTION
I've updated the package development docs so that PyPi and test PyPi get talked about in different sections, and to make clear when they should be used. I've also removed some outdated stuff about `twine`.

Let me know if you think of anything else I should add