### PR TITLE
Fixing precommit isort config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,8 @@ repos:
     hooks:
       - id: check-merge-conflict
       - id: debug-statements
-  - repo: https://github.com/timothycrosley/isort
-    rev: "5.10.1"
+  - repo: https://github.com/PyCQA/isort
+    rev: "5.12.0"
     hooks:
       - id: isort
         additional_dependencies: [toml]


### PR DESCRIPTION
This simply replaces the `isort` repo in `.pre-commit-config.yaml`.

Fixes #54 