### PR TITLE
Allow unverified metadata servers

### DIFF
--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -35,6 +35,7 @@ contact_orcid = 0000-0003-3378-2814
 [metadata]
 api = https://safeproject.net
 token = xyz
+ssl_verify = True
 ```
 
 ### Locations
@@ -160,6 +161,11 @@ server, which provides an API allowing searches across all uploaded datasets. A 
 package in the SAFE data ecosystem
 ([`safedata`](https://imperialcollegelondon.github.io/safedata/)) has been built, in
 order to simplify the process of querying this API for end users.
+
+In production use, the metadata server should be set up with a properly validated SSL
+certificate to allow HTTPS, and this is relatively easy using LetsEncrypt. However, when
+setting up and testing a system, requiring a valid certificate can be a road block and
+the SSL verification can be turned off.
 
 ## Configuration file location
 

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -35,7 +35,7 @@ contact_orcid = 0000-0003-3378-2814
 [metadata]
 api = https://safeproject.net
 token = xyz
-ssl_verify = True
+ssl_verify = true
 ```
 
 ### Locations

--- a/safedata_validator/resources.py
+++ b/safedata_validator/resources.py
@@ -73,7 +73,11 @@ CONFIGSPEC = {
         "contact_affiliation": "string(default=None)",
         "contact_orcid": "string(default=None)",
     },
-    "metadata": {"api": "string(default=None)", "token": "string(default=None)"},
+    "metadata": {
+        "api": "string(default=None)",
+        "token": "string(default=None)",
+        "ssl_verify": "boolean(default=True)",
+    },
 }
 """dict: The safedata_validator package use the `configobj.ConfigObj`
 package to handle resource configuration. This dict defines the basic expected

--- a/safedata_validator/zenodo.py
+++ b/safedata_validator/zenodo.py
@@ -95,6 +95,7 @@ def _resources_to_zenodo_api(resources: Optional[Resources] = None) -> dict:
     metadata_token = resources.metadata.token
     if metadata_api is None or metadata_token is None:
         config_fail = True
+    metadata_ssl = resources.metadata.ssl_verify
 
     if config_fail:
         raise RuntimeError("safedata_validator not configured for Zenodo functions")
@@ -108,6 +109,7 @@ def _resources_to_zenodo_api(resources: Optional[Resources] = None) -> dict:
         "zcorc": contact_orcid,
         "mdapi": metadata_api,
         "mdtoken": metadata_token,
+        "mdssl": metadata_ssl,
     }
 
 
@@ -562,6 +564,7 @@ def post_metadata(
         f"{zres['mdapi']}/post_metadata",
         params={"token": zres["mdtoken"]},
         json=payload,
+        verify=zres["mdssl"],
     )
 
     # trap errors in uploading metadata and tidy up


### PR DESCRIPTION
This PR adds the `ssl_verify` flag to the metadata configuration file, which is used to set the `verify` argument to `requests.post` in `zenodo.post_metadata`.

Fixes #52 