### PR TITLE
Make project IDs optional

### DIFF
--- a/docs/command_line_tools/command_line_usage/safedata_validate.txt
+++ b/docs/command_line_tools/command_line_usage/safedata_validate.txt
@@ -29,7 +29,8 @@ options:
   -p VALID_PID, --project_id VALID_PID
                         If provided, check that the project ID within the file
                         matches this integer. Multiple values can be provided
-                        to generate a set of valid IDs.
+                        to generate a set of valid IDs. This option only makes
+                        sense to use if your organisation uses project IDs.
   -r RESOURCES, --resources RESOURCES
                         A path to a resources configuration file
   --validate_doi        Check the validity of any publication DOIs, provided

--- a/docs/data_providers/data_format/summary.md
+++ b/docs/data_providers/data_format/summary.md
@@ -54,8 +54,8 @@ a single value for each field.
 
 * **Project ID**: This is only used if the organisation you are uploading to uses
   projects to group datasets. If they are then you should obtain relevant project IDs
-  from the organisation's data manager and add them in your Summary worksheet. 
-  The legacy name for this field is `SAFE Project ID`: using this name will still work 
+  from the organisation's data manager and add them in your Summary worksheet.
+  The legacy name for this field is `SAFE Project ID`: using this name will still work
   but is not the preferred option.
 * **Title**: This should be a short informative title for the dataset: it will
   be used as the public title for the dataset so make sure it is clear and
@@ -123,7 +123,7 @@ shown below, not the full URL [](http://orcid.org/0000-0002-7005-1394).
 |                    |                         |  |  |
 |--------------------|-------------------------|--|--|
 | Author name        | Orme, David             |  |  |
-| Author email       | d.orme@imperial.ac.uk   |  |  |
+| Author email       | <d.orme@imperial.ac.uk>   |  |  |
 | Author affiliation | Imperial College London |  |  |
 | Author ORCID       | 0000-0002-7005-1394     |  |  |
 
@@ -322,7 +322,7 @@ at SAFE.
 | Access status             | Embargo                                                     |                                                              |                                  |
 | Embargo date              | 03/09/18                                                    |                                                              |                                  |
 | Author name               | Orme, David                                                 |                                                              |                                  |
-| Author email              | d.orme@imperial.ac.uk                                       |                                                              |                                  |
+| Author email              | <d.orme@imperial.ac.uk>                                       |                                                              |                                  |
 | Author affiliation        | Imperial College London                                     |                                                              |                                  |
 | Author ORCID              | 0000-0002-7005-1394                                         |                                                              |                                  |
 | Worksheet name            | DF                                                          | Incidence                                                    | Transects                        |

--- a/docs/data_providers/data_format/summary.md
+++ b/docs/data_providers/data_format/summary.md
@@ -54,11 +54,9 @@ a single value for each field.
 
 * **Project ID**: This is only used if the organisation you are uploading to uses
   projects to group datasets. If they are then you should obtain relevant project IDs
-  from the organisation's data manager. Then when you upload your dataset, you will also
-  be asked to choose a project for your dataset: these two numbers must match. Note that
-  you can only upload data to a project of which you are a member. The legacy name for
-  this field is **SAFE Project ID**, using this name will still work but is not the
-  preferred option.
+  from the organisation's data manager and add them in your Summary worksheet. 
+  The legacy name for this field is `SAFE Project ID`: using this name will still work 
+  but is not the preferred option.
 * **Title**: This should be a short informative title for the dataset: it will
   be used as the public title for the dataset so make sure it is clear and
   grammatical!

--- a/docs/data_providers/data_format/summary.md
+++ b/docs/data_providers/data_format/summary.md
@@ -52,10 +52,13 @@ tbody tr td:first-child {
 This block provides a set of core details for the dataset. You can only provide
 a single value for each field.
 
-* **SAFE Project ID**: This is the project number from the SAFE project website.
-  When you upload your dataset, you will also be asked to choose a project for
-  your dataset: these two numbers must match. Note that you can only upload data
-  to a project of which you are a member.
+* **Project ID**: This is only used if the organisation you are uploading to uses
+  projects to group datasets. If they are then you should obtain relevant project IDs
+  from the organisation's data manager. Then when you upload your dataset, you will also
+  be asked to choose a project for your dataset: these two numbers must match. Note that
+  you can only upload data to a project of which you are a member. The legacy name for
+  this field is **SAFE Project ID**, using this name will still work but is not the
+  preferred option.
 * **Title**: This should be a short informative title for the dataset: it will
   be used as the public title for the dataset so make sure it is clear and
   grammatical!
@@ -66,7 +69,7 @@ a single value for each field.
 
 |                 |                                   |  |  |
 |-----------------|-----------------------------------|--|--|
-| SAFE Project ID | 1                                 |  |  |
+| Project ID      | 1                                 |  |  |
 | Title           | Example data for the SAFE Project |  |  |
 | Description     | This is an example dataset.       |  |  |
 
@@ -315,7 +318,7 @@ at SAFE.
 <!-- markdownlint-disable MD013 -->
 |                           |                                                             |                                                              |                                  |
 |---------------------------|-------------------------------------------------------------|--------------------------------------------------------------|----------------------------------|
-| SAFE Project ID           | 1                                                           |                                                              |                                  |
+| Project ID                | 1                                                           |                                                              |                                  |
 | Title                     | Example data for the SAFE Project                           |                                                              |                                  |
 | Description               | This is an example dataset.                                 |                                                              |                                  |
 | Access status             | Embargo                                                     |                                                              |                                  |

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -7,6 +7,8 @@ be included regardless of what the package is being configured to do.
 
 ## Configuration file format
 
+TODO - Update this once I have decided on a format for the config option.
+
 The file structure for the configuration file is a simple text file containing
 the details below:
 

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -115,17 +115,16 @@ when no NCBI taxa are included.
 
 ### Project IDs
 
-The SAFE data system was initially developed as part of the SAFE project, which
+The `safedata` system was initially developed as part of the SAFE project, which
 organises datasets into projects. Each project is identified using a unique
 identification number, and each dataset is associated with one or more projects using
-these project ID numbers. We anticipate that other deployments of the SAFE data system
+these project ID numbers. We anticipate that other deployments of the `safedata` system
 may not wish to organise datasets in this manner. If so, the checking of project IDs can
 be turned off by setting the `use_project_ids` option  to `False`. With this option off,
 datasets will **fail validation** if they contain project IDs.
 
 !!! Warning
-
-  Each deployment of the SAFE data system will have to make a choice of whether or not
+  Each deployment of the `safedata` system will have to make a choice of whether or not
   to organise datasets into project. Once this choice has been made it will be binding.
   As such, this option should only be changed by the relevant data manager during the
   initial setup of the data system.

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -7,8 +7,6 @@ be included regardless of what the package is being configured to do.
 
 ## Configuration file format
 
-TODO - Update this once I have decided on a format for the config option.
-
 The file structure for the configuration file is a simple text file containing
 the details below:
 
@@ -17,6 +15,7 @@ gazetteer = /path/to/gazeteer.geojson
 location_aliases = /path/to/location_aliases.csv
 gbif_database = /path/to/local/backbone.sqlite3
 ncbi_database = /path/to/local/ncbi_database.sqlite3
+use_project_ids = True
 [extents]
 temporal_soft_extent = 2002-02-02, 2030-01-31
 temporal_hard_extent = 2002-02-01, 2030-02-01
@@ -113,6 +112,23 @@ even when no GBIF taxa are included.
 The `ncbi_database` entry contains the path to the required local copy of the NCBI
 database, ([see here](build_local_ncbi.md)). This database **must** be included even
 when no NCBI taxa are included.
+
+### Project IDs
+
+The SAFE data system was initially developed as part of the SAFE project, which
+organises datasets into projects. Each project is identified using a unique
+identification number, and each dataset is associated with one or more projects using
+these project ID numbers. We anticipate that other deployments of the SAFE data system
+may not wish to organise datasets in this manner. If so, the checking of project IDs can
+be turned off by setting the `use_project_ids` option  to `False`. With this option off,
+datasets will **fail validation** if they contain project IDs.
+
+!!! Warning
+
+  Each deployment of the SAFE data system will have to make a choice of whether or not
+  to organise datasets into project. Once this choice has been made it will be binding.
+  As such, this option should only be changed by the relevant data manager during the
+  initial setup of the data system.
 
 ### Extents
 

--- a/safedata_validator/entry_points.py
+++ b/safedata_validator/entry_points.py
@@ -74,9 +74,9 @@ def _safedata_validator_cli():
         default=None,
         type=int,
         action="append",
-        help="If provided, check that the project ID within the file "
-        "matches this integer. Multiple values can be provided "
-        "to generate a set of valid IDs.",
+        help="If provided, check that the project ID within the file matches this "
+        "integer. Multiple values can be provided to generate a set of valid IDs. This "
+        "option only makes sense to use if your organisation uses project IDs.",
         dest="valid_pid",
     )
     parser.add_argument(

--- a/safedata_validator/field.py
+++ b/safedata_validator/field.py
@@ -118,6 +118,7 @@ class Dataset:
             longitudinal_extent=self.longitudinal_extent,
         )
 
+    # TODO - Work out if this function needs to change now project IDs are optional
     def load_from_workbook(
         self,
         filename: str,

--- a/safedata_validator/field.py
+++ b/safedata_validator/field.py
@@ -118,7 +118,6 @@ class Dataset:
             longitudinal_extent=self.longitudinal_extent,
         )
 
-    # TODO - Work out if this function needs to change now project IDs are optional
     def load_from_workbook(
         self,
         filename: str,

--- a/safedata_validator/resources.py
+++ b/safedata_validator/resources.py
@@ -154,6 +154,7 @@ class Resources:
         location_aliases: The path to the location_aliases file
         gbif_database: The path to the GBIF database file
         ncbi_database: The path to the NCBI database file
+        use_project_ids: Whether organisation uses project IDs or not
         valid_locations: The locations defined in the locations file
         location_aliases: Location aliases defined in the locations file
         extents: A DotMap of extent data
@@ -214,7 +215,7 @@ class Resources:
         self.ncbi_database = config_loaded.ncbi_database
         self.config_type = config_loaded.config_type
         self.config_source = config_loaded.config_source
-        self.use_project_ids = config_loaded.config_source
+        self.use_project_ids = config_loaded.use_project_ids
 
         self.extents = config_loaded.extents
         self.zenodo = config_loaded.zenodo

--- a/safedata_validator/resources.py
+++ b/safedata_validator/resources.py
@@ -49,11 +49,14 @@ from safedata_validator.logger import (
     loggerinfo_push_pop,
 )
 
+# TODO - Work out whether CONFIGSPEC needs to be tested
+
 CONFIGSPEC = {
     "gazetteer": "string()",
     "location_aliases": "string()",
     "gbif_database": "string()",
     "ncbi_database": "string()",
+    "use_project_ids": "boolean(default=True)",
     "extents": {
         "temporal_soft_extent": "date_list(min=2, max=2, default=None)",
         "temporal_hard_extent": "date_list(min=2, max=2, default=None)",

--- a/safedata_validator/resources.py
+++ b/safedata_validator/resources.py
@@ -131,6 +131,7 @@ def date_list(value: str, min: str, max: str) -> list[date]:
     return out
 
 
+# TODO - Work out whether the changes to __init__ need to be tested
 @loggerinfo_push_pop("Configuring Resources")
 class Resources:
     """Load and check validation resources.
@@ -213,6 +214,7 @@ class Resources:
         self.ncbi_database = config_loaded.ncbi_database
         self.config_type = config_loaded.config_type
         self.config_source = config_loaded.config_source
+        self.use_project_ids = config_loaded.config_source
 
         self.extents = config_loaded.extents
         self.zenodo = config_loaded.zenodo
@@ -244,9 +246,11 @@ class Resources:
             config: Passed from Resources.__init__()
             cfg_type: Identifies the route used to provide the configuration details
 
+        Raises:
+            RuntimeError: If the file does not exist, or has issues.
+
         Returns:
-             If the file does not exist, the function returns None. Otherwise,
-             it returns a DotMap of config parameters.
+            Returns a DotMap of config parameters.
         """
 
         # Otherwise, there is a file, so try and use it and now raise if there

--- a/safedata_validator/resources.py
+++ b/safedata_validator/resources.py
@@ -49,8 +49,6 @@ from safedata_validator.logger import (
     loggerinfo_push_pop,
 )
 
-# TODO - Work out whether CONFIGSPEC needs to be tested
-
 CONFIGSPEC = {
     "gazetteer": "string()",
     "location_aliases": "string()",
@@ -131,7 +129,6 @@ def date_list(value: str, min: str, max: str) -> list[date]:
     return out
 
 
-# TODO - Work out whether the changes to __init__ need to be tested
 @loggerinfo_push_pop("Configuring Resources")
 class Resources:
     """Load and check validation resources.

--- a/safedata_validator/resources.py
+++ b/safedata_validator/resources.py
@@ -151,7 +151,7 @@ class Resources:
         location_aliases: The path to the location_aliases file
         gbif_database: The path to the GBIF database file
         ncbi_database: The path to the NCBI database file
-        use_project_ids: Whether organisation uses project IDs or not
+        use_project_ids: Whether this organisation uses project IDs or not
         valid_locations: The locations defined in the locations file
         location_aliases: Location aliases defined in the locations file
         extents: A DotMap of extent data

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -123,6 +123,7 @@ class Summary:
         # an internal field name, if needed in the code or by Zenodo.
 
         # TODO - Change field here to allow multiple options for project ID
+        # TODO - Once this alias is defined check that it is properly documented
         # TODO - Check that these changes to make project_ids optional works as intended
         # TODO - Need to make sure metadata is saved correctly when there's no project
         # ID

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -786,8 +786,7 @@ class Summary:
             self.project_id = pid
 
 
-# TODO - Work out how to test this function
-def load_rows_from_worksheet(worksheet: Worksheet) -> list[str]:
+def load_rows_from_worksheet(worksheet: Worksheet) -> list[tuple]:
     """Load worksheet rows, removing blank rows.
 
     Args:

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -123,7 +123,7 @@ class Summary:
         # an internal field name, if needed in the code or by Zenodo.
 
         # TODO - Change field here to allow multiple options for project ID
-        # TODO - Check that this change to make project_ids optional works as intended
+        # TODO - Check that these changes to make project_ids optional works as intended
         # TODO - Need to make sure metadata is saved correctly when there's no project
         # ID
         self.fields: dict[str, tuple[list, bool, str, bool]] = dict(

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -268,12 +268,7 @@ class Summary:
 
         self.validate_doi = validate_doi
 
-        # load worksheet rows, removing blank rows
-        # TODO - make 'internal' blank rows an error.
-        rows = []
-        for this_row in worksheet.iter_rows(values_only=True):
-            if not all([blank_value(vl) for vl in this_row]):
-                rows.append(this_row)
+        rows = load_rows_from_worksheet(worksheet)
 
         self._ncols = worksheet.max_column
 
@@ -789,3 +784,19 @@ class Summary:
             )
         else:
             self.project_id = pid
+
+
+# TODO - Work out how to test this function
+def load_rows_from_worksheet(worksheet: Worksheet) -> list[str]:
+    """Load worksheet rows, removing blank rows.
+
+    Args:
+        worksheet: An openpyxl worksheet instance.
+    """
+    # TODO - make 'internal' blank rows an error.
+    rows = []
+    for this_row in worksheet.iter_rows(values_only=True):
+        if not all([blank_value(vl) for vl in this_row]):
+            rows.append(this_row)
+
+    return rows

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -123,9 +123,6 @@ class Summary:
         # in the summary sheet, if that field is mandatory within the set and
         # an internal field name, if needed in the code or by Zenodo.
 
-        # TODO - Once this alias is defined check that it is properly documented
-        # TODO - Need to make sure metadata is saved correctly when there's no project
-        # ID
         self.fields: dict[str, tuple[list, bool, str, bool]] = dict(
             core=(
                 [
@@ -815,6 +812,7 @@ class Summary:
 
         self.access = access
 
+    # TODO - Need to check that this actually handles the no pid case
     @loggerinfo_push_pop("Loading core metadata")
     def _load_core(self, found):
 

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -84,6 +84,9 @@ class Summary:
     # in the summary sheet, if that field is mandatory within the set and
     # an internal field name, if needed in the code or by Zenodo.
 
+    # TODO - Change field here to allow multiple options for project ID
+    # TODO - Change so that no project ID has to be provided (if that's how the config
+    # is setup)
     fields: dict[str, tuple[list, bool, str, bool]] = dict(
         core=(
             [
@@ -219,6 +222,7 @@ class Summary:
         self.valid_pid: Optional[list[int]] = None
         self.validate_doi = False
 
+    # TODO - Work if this function needs to change now that project IDs are optional
     @loggerinfo_push_pop("Checking Summary worksheet")
     def load(
         self,
@@ -748,6 +752,7 @@ class Summary:
 
         self.access = access
 
+    # TODO - Change this to make providing a project ID optional
     @loggerinfo_push_pop("Loading core metadata")
     def _load_core(self):
 
@@ -764,8 +769,7 @@ class Summary:
         # Check the value is in the provided list
         if pid is not None and self.valid_pid is not None and pid not in self.valid_pid:
             LOGGER.error(
-                f"SAFE Project ID in file ({pid}) does not match any "
-                f"provided project ids: ",
+                f"Project ID in file ({pid}) does not match any provided project ids: ",
                 extra={"join": self.valid_pid},
             )
         else:

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -46,10 +46,8 @@ class Summary:
         resources: An instance of Resources providing the safedata_validator
             configuration.
 
-    Class Attributes:
-        fields: A dictionary setting the expected metadata fields for summary tables.
-
     Attributes:
+        fields: A dictionary setting the expected metadata fields for summary tables.
         project_id: An integer project ID code
         title: A string giving the dataset title.
         description: A string giving a description of the dataset
@@ -68,121 +66,6 @@ class Summary:
         valid_pid: A list of valid project ID values.
         validate_doi: A boolean flag indicating whether DOI values should be validated.
     """
-
-    # Class attribute to define the metadata that may be present.
-    # These are defined in blocks of related rows described in 4-tuples:
-    #  0: a list of tuples giving the rows in the block:
-    #     * row header key
-    #     * mandatory within the block
-    #     * 'internal' name - also maps to Zenodo fields
-    #     * accepted types
-    #  1: is the block mandatory (bool)
-    #  2: the title of the block for the logger
-    #  3: should there be only one record (bool)
-    #
-    # Each entry in the list of rows provides the row header that appears
-    # in the summary sheet, if that field is mandatory within the set and
-    # an internal field name, if needed in the code or by Zenodo.
-
-    # TODO - Change field here to allow multiple options for project ID
-    # TODO - Change so that no project ID has to be provided (if that's how the config
-    # is setup)
-    fields: dict[str, tuple[list, bool, str, bool]] = dict(
-        core=(
-            [
-                ("safe project id", True, "pid", int),
-                ("title", True, None, str),
-                ("description", True, None, str),
-            ],
-            True,
-            "Core fields",
-            True,
-        ),
-        access=(
-            [
-                ("access status", True, "access", str),
-                ("embargo date", False, "embargo_date", datetime.datetime),
-                ("access conditions", False, "access_conditions", str),
-            ],
-            True,
-            "Access details",
-            True,
-        ),
-        keywords=([("keywords", True, None, str)], True, "Keywords", False),
-        doi=([("publication doi", True, None, str)], False, "DOI", False),
-        date=(
-            [
-                ("start date", True, None, datetime.datetime),
-                ("end date", True, None, datetime.datetime),
-            ],
-            False,
-            "Date Extents",
-            True,
-        ),
-        geo=(
-            [
-                ("west", True, None, float),
-                ("east", True, None, float),
-                ("south", True, None, float),
-                ("north", True, None, float),
-            ],
-            False,
-            "Geographic Extents",
-            True,
-        ),
-        authors=(
-            [
-                ("author name", True, "name", str),
-                ("author affiliation", False, "affiliation", str),
-                ("author email", False, "email", str),
-                ("author orcid", False, "orcid", str),
-            ],
-            True,
-            "Authors",
-            False,
-        ),
-        funding=(
-            [
-                ("funding body", True, "body", str),
-                ("funding type", True, "type", str),
-                ("funding reference", False, "ref", (str, int, float)),
-                ("funding link", False, "url", str),
-            ],
-            False,
-            "Funding Bodies",
-            False,
-        ),
-        external=(
-            [
-                ("external file", True, "file", str),
-                ("external file description", True, "description", str),
-            ],
-            False,
-            "External Files",
-            False,
-        ),
-        worksheet=(
-            [
-                ("worksheet name", True, "name", str),
-                ("worksheet title", True, "title", str),
-                ("worksheet description", True, "description", str),
-                ("worksheet external file", False, "external", str),
-            ],
-            False,
-            "Worksheets",
-            False,
-        ),
-        permits=(
-            [
-                ("permit type", True, "type", str),
-                ("permit authority", True, "authority", str),
-                ("permit number", True, "number", (str, int, float)),
-            ],
-            False,
-            "Permits",
-            False,
-        ),
-    )
 
     def __init__(self, resources: Resources):
 
@@ -221,6 +104,120 @@ class Summary:
         self.n_errors: int = 0
         self.valid_pid: Optional[list[int]] = None
         self.validate_doi = False
+
+        # Class attribute to define the metadata that may be present.
+        # These are defined in blocks of related rows described in 4-tuples:
+        #  0: a list of tuples giving the rows in the block:
+        #     * row header key
+        #     * mandatory within the block
+        #     * 'internal' name - also maps to Zenodo fields
+        #     * accepted types
+        #  1: is the block mandatory (bool)
+        #  2: the title of the block for the logger
+        #  3: should there be only one record (bool)
+        #
+        # Each entry in the list of rows provides the row header that appears
+        # in the summary sheet, if that field is mandatory within the set and
+        # an internal field name, if needed in the code or by Zenodo.
+
+        # TODO - Change field here to allow multiple options for project ID
+        # TODO - Check that this change to make project_ids optional works as intended
+        self.fields: dict[str, tuple[list, bool, str, bool]] = dict(
+            core=(
+                [
+                    ("safe project id", resources.use_project_ids, "pid", int),
+                    ("title", True, None, str),
+                    ("description", True, None, str),
+                ],
+                True,
+                "Core fields",
+                True,
+            ),
+            access=(
+                [
+                    ("access status", True, "access", str),
+                    ("embargo date", False, "embargo_date", datetime.datetime),
+                    ("access conditions", False, "access_conditions", str),
+                ],
+                True,
+                "Access details",
+                True,
+            ),
+            keywords=([("keywords", True, None, str)], True, "Keywords", False),
+            doi=([("publication doi", True, None, str)], False, "DOI", False),
+            date=(
+                [
+                    ("start date", True, None, datetime.datetime),
+                    ("end date", True, None, datetime.datetime),
+                ],
+                False,
+                "Date Extents",
+                True,
+            ),
+            geo=(
+                [
+                    ("west", True, None, float),
+                    ("east", True, None, float),
+                    ("south", True, None, float),
+                    ("north", True, None, float),
+                ],
+                False,
+                "Geographic Extents",
+                True,
+            ),
+            authors=(
+                [
+                    ("author name", True, "name", str),
+                    ("author affiliation", False, "affiliation", str),
+                    ("author email", False, "email", str),
+                    ("author orcid", False, "orcid", str),
+                ],
+                True,
+                "Authors",
+                False,
+            ),
+            funding=(
+                [
+                    ("funding body", True, "body", str),
+                    ("funding type", True, "type", str),
+                    ("funding reference", False, "ref", (str, int, float)),
+                    ("funding link", False, "url", str),
+                ],
+                False,
+                "Funding Bodies",
+                False,
+            ),
+            external=(
+                [
+                    ("external file", True, "file", str),
+                    ("external file description", True, "description", str),
+                ],
+                False,
+                "External Files",
+                False,
+            ),
+            worksheet=(
+                [
+                    ("worksheet name", True, "name", str),
+                    ("worksheet title", True, "title", str),
+                    ("worksheet description", True, "description", str),
+                    ("worksheet external file", False, "external", str),
+                ],
+                False,
+                "Worksheets",
+                False,
+            ),
+            permits=(
+                [
+                    ("permit type", True, "type", str),
+                    ("permit authority", True, "authority", str),
+                    ("permit number", True, "number", (str, int, float)),
+                ],
+                False,
+                "Permits",
+                False,
+            ),
+        )
 
     # TODO - Work if this function needs to change now that project IDs are optional
     @loggerinfo_push_pop("Checking Summary worksheet")

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -124,7 +124,6 @@ class Summary:
         # an internal field name, if needed in the code or by Zenodo.
 
         # TODO - Once this alias is defined check that it is properly documented
-        # TODO - Check that these changes to make project_ids optional works as intended
         # TODO - Need to make sure metadata is saved correctly when there's no project
         # ID
         self.fields: dict[str, tuple[list, bool, str, bool]] = dict(
@@ -316,7 +315,7 @@ class Summary:
                 )
 
         # Now process the field blocks
-        self._load_core()
+        self._load_core(found)
         self._load_access_details()
         self._load_authors()
         self._load_keywords()
@@ -816,15 +815,21 @@ class Summary:
 
         self.access = access
 
-    # TODO - I think the problems of adding a no-pid option are fixed in the function
-    # that calls this one, but should check this later
-    # Whether this function needs to change hinges on exactly how self._read_block works
-    # Pretty certain that there needs to be changes
     @loggerinfo_push_pop("Loading core metadata")
-    def _load_core(self):
+    def _load_core(self, found):
 
-        # Now check core rows
-        core = self._read_block(*self.fields["core"])
+        # Extract all core fields
+        core_fields = self.fields["core"]
+
+        # Make list of all core aliases
+        aliases = [core_field[4] for core_field in core_fields[0]]
+        # Then replace core field names with an alias where appropriate
+        for idx, alias_set in enumerate(aliases):
+            for alias in alias_set:
+                if alias in found:
+                    core_fields[0][idx] = (alias,) + core_fields[0][idx][1:4]
+
+        core = self._read_block(*core_fields)
         core = core[0]
 
         self.title = core["title"]

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -812,7 +812,6 @@ class Summary:
 
         self.access = access
 
-    # TODO - Need to check that this actually handles the no pid case
     @loggerinfo_push_pop("Loading core metadata")
     def _load_core(self, found):
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -115,6 +115,7 @@ def config_filesystem(fs):
         "location_aliases = ",
         "gbif_database = ",
         "ncbi_database = ",
+        "use_project_ids = True",
         "[extents]",
         "temporal_soft_extent = 2002-02-02, 2030-01-31",
         "temporal_hard_extent = 2002-02-01, 2030-02-01",

--- a/test/test_resources.py
+++ b/test/test_resources.py
@@ -332,6 +332,18 @@ def nested_set(dic, keys, value):
             id="NCBI wrong SQLite",
         ),
         pytest.param(
+            ((["use_project_ids"], ["nonsense"]),),
+            ((4, "use_project_ids = nonsense"),),
+            RuntimeError,
+            (
+                (INFO, "Configuring Resources"),
+                (INFO, "Configuring resources from init "),
+                (CRITICAL, "Configuration issues"),
+                (CRITICAL, "In config 'use_project_ids':"),
+            ),
+            id="Testing use_project_ids not bool",
+        ),
+        pytest.param(
             ((["extents", "latitudinal_hard_extent"], ["-90deg", "90deg"]),),
             ((8, "latitudinal_hard_extent = -90deg, 90deg"),),
             RuntimeError,

--- a/test/test_resources.py
+++ b/test/test_resources.py
@@ -23,6 +23,7 @@ def config_file_list():
         f"location_aliases = {FIXTURE_FILES.rf.localias_file}",
         f"gbif_database = {FIXTURE_FILES.rf.gbif_file}",
         f"ncbi_database = {FIXTURE_FILES.rf.ncbi_file}",
+        "use_project_ids = False",
         "[extents]",
         "temporal_soft_extent = 2002-02-01, 2030-02-01",
         "temporal_hard_extent = 2002-02-01, 2030-02-01",
@@ -48,6 +49,7 @@ def config_file_dict():
         "location_aliases": FIXTURE_FILES.rf.localias_file,
         "gbif_database": FIXTURE_FILES.rf.gbif_file,
         "ncbi_database": FIXTURE_FILES.rf.ncbi_file,
+        "use_project_ids": True,
         "extents": {
             "temporal_soft_extent": ["2002-02-01", "2030-02-01"],
             "temporal_hard_extent": ["2002-02-01", "2030-02-01"],
@@ -331,7 +333,7 @@ def nested_set(dic, keys, value):
         ),
         pytest.param(
             ((["extents", "latitudinal_hard_extent"], ["-90deg", "90deg"]),),
-            ((7, "latitudinal_hard_extent = -90deg, 90deg"),),
+            ((8, "latitudinal_hard_extent = -90deg, 90deg"),),
             RuntimeError,
             (
                 (INFO, "Configuring Resources"),

--- a/test/test_summary.py
+++ b/test/test_summary.py
@@ -4,6 +4,7 @@ from logging import ERROR, INFO
 
 import pytest
 from dotmap import DotMap
+from openpyxl import Workbook
 from sympy import Sum
 
 from safedata_validator.logger import LOGGER
@@ -1338,3 +1339,36 @@ def test_load_worksheet_project_ids(
         fixture_summary.load(DotMap({"max_column": 20}), ())
 
     log_check(caplog, expected_log_entries)
+
+
+@pytest.mark.parametrize(
+    argnames=["data", "expected_rows"],
+    argvalues=[
+        pytest.param(
+            [["header"]],
+            [("header",)],
+            id="simple case",
+        ),
+        pytest.param(
+            [["header_1", 1, 3], ["header_2", 2, 6], ["header_3", 3, 9]],
+            [("header_1", 1, 3), ("header_2", 2, 6), ("header_3", 3, 9)],
+            id="complex case",
+        ),
+    ],
+)
+def test_load_rows_from_worksheet(data, expected_rows):
+    """Test that function to load rows from a worksheet works as intended."""
+    from safedata_validator.summary import load_rows_from_worksheet
+
+    # Make an empty worksheet
+    workbook = Workbook()
+    worksheet = workbook.active
+
+    # Loop through the rows of the list of lists and add them to the worksheet
+    for row in data:
+        worksheet.append(row)
+
+    rows = load_rows_from_worksheet(worksheet)
+
+    # Test parsed rows match what was expected
+    assert rows == expected_rows

--- a/test/test_summary.py
+++ b/test/test_summary.py
@@ -1186,6 +1186,7 @@ def test_load_valid_project_ids(
     log_check(caplog, expected_log_entries)
 
 
+# Should fail if both provided
 @pytest.mark.parametrize(
     argnames=["checking", "header_row", "expected_log_entries"],
     argvalues=[
@@ -1220,11 +1221,30 @@ def test_load_valid_project_ids(
             ],
             (
                 (INFO, "Checking Summary worksheet"),
-                (ERROR, "Missing mandatory metadata fields:"),
+                (ERROR, "One of the following fields must be included:"),
                 (INFO, "Loading core metadata"),
                 (ERROR, "No Core fields metadata found"),
             ),
             id="missing pid header",
+        ),
+        pytest.param(
+            True,
+            [
+                ["title"],
+                ["description"],
+                ["access status"],
+                ["author name"],
+                ["keywords"],
+                ["project id"],
+                ["safe project id"],
+            ],
+            (
+                (INFO, "Checking Summary worksheet"),
+                (ERROR, "Only one of the following fields should be included:"),
+                (INFO, "Loading core metadata"),
+                (ERROR, "No Core fields metadata found"),
+            ),
+            id="duplicated pid header",
         ),
         pytest.param(
             False,
@@ -1235,6 +1255,29 @@ def test_load_valid_project_ids(
                 ["author name"],
                 ["keywords"],
                 ["safe project id"],
+            ],
+            (
+                (INFO, "Checking Summary worksheet"),
+                (ERROR, "Unknown metadata fields:"),
+                (
+                    ERROR,
+                    "Project ID field should not be included, as your data manager does"
+                    " not use projects!",
+                ),
+                (INFO, "Loading core metadata"),
+                (ERROR, "No Core fields metadata found"),
+            ),
+            id="unexpected pid header (legacy)",
+        ),
+        pytest.param(
+            False,
+            [
+                ["title"],
+                ["description"],
+                ["access status"],
+                ["author name"],
+                ["keywords"],
+                ["project id"],
             ],
             (
                 (INFO, "Checking Summary worksheet"),
@@ -1257,6 +1300,23 @@ def test_load_valid_project_ids(
                 ["author name"],
                 ["keywords"],
                 ["safe project id"],
+            ],
+            (
+                (INFO, "Checking Summary worksheet"),
+                (INFO, "Loading core metadata"),
+                (ERROR, "No Core fields metadata found"),
+            ),
+            id="all fine with checking (legacy)",
+        ),
+        pytest.param(
+            True,
+            [
+                ["title"],
+                ["description"],
+                ["access status"],
+                ["author name"],
+                ["keywords"],
+                ["project id"],
             ],
             (
                 (INFO, "Checking Summary worksheet"),

--- a/test/test_summary.py
+++ b/test/test_summary.py
@@ -1087,3 +1087,13 @@ def test_summary_load(fixture_summary, example_excel_files, n_errors):
     )
 
     assert fixture_summary.n_errors == n_errors
+
+
+# TODO - Flesh out this test
+# Might have to make PID checking a separate function to make testing easier
+# 1) Valid PID + checking => No error
+# 2) Valid PID + no checking => ???
+# 3) No PID + no checking => No error
+# 4) No PID + checking => Error
+def test_project_id(fixture_summary):
+    """Tests that project ID are only checked when required."""


### PR DESCRIPTION
This PR makes the use of project IDs a configurable option. It also changes the default name for the field from "safe project id" to "project id", and introduces alias checking so that uses of "safe project id" are handled correctly.

The alias checking is only properly set up for mandatory core fields, but hopefully has been written in a way that should be extensible to other fields if there are other places we want to use aliases.

Fixes #50