### PR TITLE
Fixes a couple of security venerabilities for release 3.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -453,7 +453,7 @@ mkdocstrings = ">=0.19"
 
 [[package]]
 name = "mpmath"
-version = "1.2.1"
+version = "1.3.0"
 description = "Python library for arbitrary-precision floating-point arithmetic"
 category = "main"
 optional = false
@@ -461,6 +461,8 @@ python-versions = "*"
 
 [package.extras]
 develop = ["codecov", "pycodestyle", "pytest (>=4.6)", "pytest-cov", "wheel"]
+docs = ["sphinx"]
+gmpy = ["gmpy2 (>=2.1.0a4)"]
 tests = ["pytest (>=4.6)"]
 
 [[package]]
@@ -1277,8 +1279,8 @@ mkdocstrings-python = [
     {file = "mkdocstrings_python-0.7.1-py3-none-any.whl", hash = "sha256:a22060bfa374697678e9af4e62b020d990dad2711c98f7a9fac5c0345bef93c7"},
 ]
 mpmath = [
-    {file = "mpmath-1.2.1-py3-none-any.whl", hash = "sha256:604bc21bd22d2322a177c73bdb573994ef76e62edd595d17e00aff24b0667e5c"},
-    {file = "mpmath-1.2.1.tar.gz", hash = "sha256:79ffb45cf9f4b101a807595bcb3e72e0396202e0b1d25d689134b48c4216a81a"},
+    {file = "mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c"},
+    {file = "mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f"},
 ]
 mypy = [
     {file = "mypy-0.991-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7d17e0a9707d0772f4a7b878f04b4fd11f6f5bcb9b3813975a9b13c9332153ab"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -738,17 +738,17 @@ pyyaml = "*"
 
 [[package]]
 name = "requests"
-version = "2.28.1"
+version = "2.31.0"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
-python-versions = ">=3.7, <4"
+python-versions = ">=3.7"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
-charset-normalizer = ">=2,<3"
+charset-normalizer = ">=2,<4"
 idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<1.27"
+urllib3 = ">=1.21.1,<3"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
@@ -951,7 +951,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "6dff9cc6fa9f9141d720b8e81ab7efbee34b07065368321460dda879d14fbeb8"
+content-hash = "22ed3bda07c44c36fac4e31fda9ea138671d9663b032bb2cbbd81de85500e45b"
 
 [metadata.files]
 appdirs = [
@@ -1439,8 +1439,8 @@ pyyaml-env-tag = [
     {file = "pyyaml_env_tag-0.1.tar.gz", hash = "sha256:70092675bda14fdec33b31ba77e7543de9ddc88f2e5b99160396572d11525bdb"},
 ]
 requests = [
-    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
-    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
+    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
+    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
 ]
 rispy = [
     {file = "rispy-0.7.1-py3-none-any.whl", hash = "sha256:130ba974f8bd95c0be2fabd8e7a82794174e99f433a36099c4b9bed80bfa9ec6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ ignore_missing_imports = true
 [tool.poetry.dependencies]
 python = "^3.9"
 openpyxl = "^3.0.10"
-requests = "^2.28.0"
+requests = "^2.31.0"
 simplejson = "^3.17.6"
 Shapely = "^1.8.2"
 appdirs = "^1.4.4"


### PR DESCRIPTION
Dependabot tried to automatically fix a couple of security venerabilities (see #66 and #67). This didn't work as `develop` still uses a pre-1.2 version of `poetry`. So I've made the fixes for the `release/3.0.0` branch (which uses `poetry >=1.2`).