### PR TITLE
Prevent Exception on empty data sheets

### DIFF
--- a/safedata_validator/field.py
+++ b/safedata_validator/field.py
@@ -491,8 +491,8 @@ class DataWorksheet:
         self.fields_loaded = False
         self.field_meta: list[dict] = []
         self.field_types = None
-        self.n_fields: int
-        self.n_trailing_empty_fields: int
+        self.n_fields: int = 0
+        self.n_trailing_empty_fields: int = 0
         self.n_descriptors: int
         self.descriptors: list = []
         self.fields: list[Union[EmptyField, BaseField]] = []

--- a/safedata_validator/taxa.py
+++ b/safedata_validator/taxa.py
@@ -1030,11 +1030,13 @@ class GBIFTaxa:
 
         if not dframe.data_columns:
             LOGGER.error("No data or only headers in GBIFTaxa worksheet")
+            FORMATTER.pop()
             return
 
         # Dupe headers likely cause serious issues, so stop
         if "duplicated" in dframe.bad_headers:
             LOGGER.error("Cannot parse taxa with duplicated headers")
+            FORMATTER.pop()
             return
 
         # Get the headers
@@ -1047,6 +1049,7 @@ class GBIFTaxa:
         if missing_core:
             # core names are not found so can't continue
             LOGGER.error("Missing core fields: ", extra={"join": missing_core})
+            FORMATTER.pop()
             return
 
         # TODO - Test this new behaviour
@@ -1072,6 +1075,7 @@ class GBIFTaxa:
                 "Unexpected (or misspelled) headers found:",
                 extra={"join": unexpected_headers},
             )
+            FORMATTER.pop()
             return
 
         # Any duplication in names

--- a/safedata_validator/taxa.py
+++ b/safedata_validator/taxa.py
@@ -1654,11 +1654,13 @@ class NCBITaxa:
 
         if not dframe.data_columns:
             LOGGER.error("No data or only headers in Taxa worksheet")
+            FORMATTER.pop()
             return
 
         # Dupe headers likely cause serious issues, so stop
         if "duplicated" in dframe.bad_headers:
             LOGGER.error("Cannot parse taxa with duplicated headers")
+            FORMATTER.pop()
             return
 
         # Get the headers
@@ -1671,6 +1673,7 @@ class NCBITaxa:
         if missing_core:
             # core names are not found so can't continue
             LOGGER.error("Missing core fields: ", extra={"join": missing_core})
+            FORMATTER.pop()
             return
 
         # Possible fields in this case are the two core fields + comments + all
@@ -1688,6 +1691,7 @@ class NCBITaxa:
                 "Unexpected (or misspelled) headers found:",
                 extra={"join": unexpected_headers},
             )
+            FORMATTER.pop()
             return
 
         # Check that at least two backbone taxa have been provided
@@ -1696,6 +1700,7 @@ class NCBITaxa:
         if len(fnd_rnks) < 2:
             # can't continue if less than two backbone ranks are provided
             LOGGER.error("Less than two backbone taxonomic ranks are provided")
+            FORMATTER.pop()
             return
 
         # Find core field indices and use to isolate non core (i.e. taxonomic) headers
@@ -1709,6 +1714,7 @@ class NCBITaxa:
                 LOGGER.error(
                     "If 'Comments' is provided as a field it must be the last column"
                 )
+                FORMATTER.pop()
                 return
             else:
                 # If it's the last header go ahead and delete it
@@ -1725,12 +1731,14 @@ class NCBITaxa:
         if "subspecies" in headers:
             if "species" not in headers:
                 LOGGER.error("If subspecies is provided so must species")
+                FORMATTER.pop()
                 return
 
         # Same check
         if "species" in headers:
             if "genus" not in headers:
                 LOGGER.error("If species is provided so must genus")
+                FORMATTER.pop()
                 return
 
         # Any duplication in names


### PR DESCRIPTION
Some legacy datasets pointing to external files have empty data worksheets: no data fields, just the header metadata fields and row numbers in Column A. At the moment, this correctly throws up error logs - because we no longer want to allow this to happen - but `DataWorksheet.n_fields` and `DataWorksheet.n_empty_fields` are currently typed but not defined which causes an Exception when printing the worksheet summary message. 

This PR defines defaults of 0 for those two values. It also adds some extra `FORMATTER.pops()` into `taxa.py` to maintain correct indenting in failure modes for `NCBITaxa` and `GBIFTaxa`.