### PR TITLE
Exception with GBIF 2016-07-25 database

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,18 @@
                 "gazetteer.geojson",
                 "location_aliases.csv"
             ]
+        },
+        {
+            "name": "_safedata_validator_cli debug",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "args": [
+                "-r",
+                "local/config_files/live_safeweb_gbif_2016_07_25.cfg",
+                "../safedata_directory/1198522/1237724/template_SinghRamesh.xlsx"
+            ]
         }
     ]
 }

--- a/devtools/debugging_an_entry_point.py
+++ b/devtools/debugging_an_entry_point.py
@@ -4,6 +4,21 @@ This script is used to debug the entry point function imported and run below. Th
 function expecting to be provided with values via command line arguments and argparse,
 and so debugging requires a way to pass those arguments in to the function.
 
+In the example provided here, the function would normally be run from the command line
+using:
+
+```sh
+safedata_validate \
+    -r local/config_files/live_safeweb_gbif_2016_07_25.cfg \
+    ../safedata_directory/1198522/1237724/template_SinghRamesh.xlsx
+```
+
+The `safedata_validate` command line function is a pointer to the
+`safedata_validator.entry_points._safedata_validator_cli` function, which then handles
+parsing those command line arguments using `argparse`. In order to allow this to be
+debugged, the _Python_ function needs to be run from within a Python debugger, and hence
+needs a way to provide those arguments to `argparse`.
+
 Within Visual Studio Code, a new debug configuration can be added to .vscode/launch.json
 containing the required arguments, which will then be passed into the script as it runs.
 The JSON to do that looks like this:

--- a/devtools/debugging_an_entry_point.py
+++ b/devtools/debugging_an_entry_point.py
@@ -1,0 +1,39 @@
+"""Test an entry point.
+
+This script is used to debug the entry point function imported and run below. This
+function expecting to be provided with values via command line arguments and argparse,
+and so debugging requires a way to pass those arguments in to the function.
+
+Within Visual Studio Code, a new debug configuration can be added to .vscode/launch.json
+containing the required arguments, which will then be passed into the script as it runs.
+The JSON to do that looks like this:
+
+```json
+    {
+        "name": "_safedata_validator_cli debug",
+        "type": "python",
+        "request": "launch",
+        "program": "${file}",
+        "console": "integratedTerminal",
+        "args": [
+            "-r",
+            "local/config_files/live_safeweb_gbif_2016_07_25.cfg",
+            "../safedata_directory/1198522/1237724/template_SinghRamesh.xlsx"
+        ]
+    }
+```
+
+From the RUN AND DEBUG pane:
+
+* make sure you have _this_ file as the active file to be debugged,
+* select the configuration name above from the dropdown,
+* start the debugger **from the RUN AND DEBUG window**.
+
+This will then run the entry point function below and provide it with the required
+arguments given in the 'args' data above. Breakpoints in the code can then be used to
+interact with the running code and allow step through.
+"""
+
+from safedata_validator.entry_points import _safedata_validator_cli
+
+_safedata_validator_cli()

--- a/safedata_validator/field.py
+++ b/safedata_validator/field.py
@@ -320,7 +320,7 @@ class Dataset:
                 )
 
         # Dedent for final result
-        FORMATTER.pop()
+        FORMATTER.pop(n=2)
 
         if COUNTER_HANDLER.counters["ERROR"] > 0:
             self.n_errors = COUNTER_HANDLER.counters["ERROR"]

--- a/safedata_validator/taxa.py
+++ b/safedata_validator/taxa.py
@@ -483,11 +483,16 @@ class GBIFValidator:
             return taxon
 
         # Add the taxonomic hierarchy, using a mapping of backbone ranks (except
-        # subspecies) to backbone table fields.
+        # subspecies) to backbone table fields. This needs to omit missing keys and
+        # more nested taxon levels: so for example a genus will have 'species_key' but
+        # it will be None (or possibly an empty string in older backbone versions that
+        # use that rather than explicit \\N in conversion)
         taxon.hierarchy = [
             (rk, taxon_row[ky])
             for rk, ky in [(r, r + "_key") for r in BACKBONE_RANKS[:-1]]
-            if ky in taxon_row.keys() and taxon_row[ky] is not None
+            if ky in taxon_row.keys()
+            and taxon_row[ky] is not None
+            and not taxon_row[ky] == ""
         ]
 
         # parent key in the local database has the odd property that the parent


### PR DESCRIPTION
The data for the GBIF taxon backbone from 2016 differs from more recent simple backbone dumps in using empty strings rather than the  `postgres` default `\N` for null values. For taxon hierarchy keys (`genus_key` etc) this is a problem because the import function only converts `\N` to SQLite `null` values. When a given taxon is processed, this results in taxon keys for inapplicable more nested taxonomic levels coming in as an empty string rather than None. The higher taxon validation then includes a bunch of  entries like `["species", ""]` for those inapplicable levels, rather than filtering them out and the id lookup raises an Exception.

We _could_ fix this by creating a special case within the GBIF database building code. It isn't ok to simply substitute all empty strings with None when building GBIF backbone databases, because that should only be applied to the taxon key fields (and not actual string fields). So, we would have to detect the 2016 dataset being built and apply updates to a named set of fields. 

I've solved this more simply here by simply adding empty strings as a condition marking an inapplicable taxon key as well as None. The PR also includes the addition of a `devtool` directory with an example script for debugging an entry point function, with a mechanism for passing command line arguments in to `argparse`.