### PR TITLE
Assorted minor bugfixes

### DIFF
--- a/safedata_validator/field.py
+++ b/safedata_validator/field.py
@@ -1833,6 +1833,8 @@ class GeoField(BaseField):
         if self.min is None or self.max is None:
             return
 
+        # Note that self.min and self.max can be None here if all data is invalid, but
+        # the update process handles None.
         if self.dataset is not None:
             if self.meta["field_type"] == "latitude":
                 self.dataset.latitudinal_extent.update([self.min, self.max])
@@ -2157,7 +2159,7 @@ class DatetimeField(BaseField):
         # Update extent if possible - note that inheritance means that isinstance
         # in extent.Extent is not successfully testing for datetime.datetime rather
         # than set datatype of datetime.date
-        if self.dataset is not None:
+        if not (self.dataset is None or self.min is None or self.max is None):
             self.dataset.temporal_extent.update([self.min.date(), self.max.date()])
 
 

--- a/safedata_validator/field.py
+++ b/safedata_validator/field.py
@@ -1615,6 +1615,7 @@ class CategoricalField(BaseField):
         to handle undeclared or unused level labels.
         """
         super().report()
+        FORMATTER.push()
 
         extra = self.reported_levels.difference(self.level_labels)
         unused = self.level_labels.difference(self.reported_levels)
@@ -1629,6 +1630,8 @@ class CategoricalField(BaseField):
                 "Categories found in levels descriptor not used in data: ",
                 extra={"join": unused},
             )
+
+        FORMATTER.pop()
 
 
 class TaxaField(BaseField):
@@ -1679,6 +1682,7 @@ class TaxaField(BaseField):
         to emit unused or unknown taxon names
         """
         super().report()
+        FORMATTER.push()
 
         # TODO - not sure about this - no other fields test for emptiness?
         if self.taxa_found == set():
@@ -1693,6 +1697,8 @@ class TaxaField(BaseField):
 
             # add the found taxa to the list of taxa used
             self.taxa.taxon_names_used.update(self.taxa_found)
+
+        FORMATTER.pop()
 
 
 class LocationsField(BaseField):
@@ -1747,6 +1753,7 @@ class LocationsField(BaseField):
         to emit undeclared location names.
         """
         super().report()
+        FORMATTER.push()
 
         # TODO - not sure about this - no other fields test for emptiness?
         if self.locations_found == set():
@@ -1763,6 +1770,8 @@ class LocationsField(BaseField):
 
             # add the found taxa to the list of taxa used
             self.locations.locations_used.update(self.locations_found)
+
+        FORMATTER.pop()
 
 
 class GeoField(BaseField):
@@ -1829,6 +1838,7 @@ class GeoField(BaseField):
         to check the coordinate range against the dataset geographic extents.
         """
         super().report()
+        FORMATTER.push()
 
         if self.min is None or self.max is None:
             return
@@ -1840,6 +1850,8 @@ class GeoField(BaseField):
                 self.dataset.latitudinal_extent.update([self.min, self.max])
             elif self.meta["field_type"] == "longitude":
                 self.dataset.longitudinal_extent.update([self.min, self.max])
+
+        FORMATTER.pop()
 
 
 class NumericTaxonField(NumericField):
@@ -1985,6 +1997,7 @@ class TimeField(BaseField):
         to flag inconsistent time formatting and invalid data.
         """
         super().report()
+        FORMATTER.push()
 
         if not self.expected_class:
             LOGGER.error(
@@ -2001,6 +2014,8 @@ class TimeField(BaseField):
                 "ISO time strings contain badly formatted values: e.g.",
                 extra={"join": self.bad_strings[:5]},
             )
+
+        FORMATTER.pop()
 
 
 class DatetimeField(BaseField):
@@ -2127,6 +2142,7 @@ class DatetimeField(BaseField):
         to flag inconsistent  date and datetime formatting and invalid data.
         """
         super().report()
+        FORMATTER.push()
 
         # INconsistent and bad data classes
         if not self.expected_class:
@@ -2161,6 +2177,8 @@ class DatetimeField(BaseField):
         # than set datatype of datetime.date
         if not (self.dataset is None or self.min is None or self.max is None):
             self.dataset.temporal_extent.update([self.min.date(), self.max.date()])
+
+        FORMATTER.pop()
 
 
 class FileField(BaseField):
@@ -2231,12 +2249,15 @@ class FileField(BaseField):
         to flag unknown files.
         """
         super().report()
+        FORMATTER.push()
 
         if self.unknown_file_names:
             LOGGER.error(
                 "Field contains external files not provided in Summary: ",
                 extra={"join": self.unknown_file_names},
             )
+
+        FORMATTER.pop()
 
 
 class EmptyField:

--- a/safedata_validator/logger.py
+++ b/safedata_validator/logger.py
@@ -116,19 +116,19 @@ class IndentFormatter(logging.Formatter):
         self.indent = indent
 
     def pop(self, n: int = 1) -> None:
-        """A convenience method to increase the indentation of the formatter.
+        """A convenience method to decrease the indentation of the formatter.
 
         Args:
-            n: Increase the indentation depth by n.
+            n: Decreease the indentation depth by n.
         """
 
         self.depth = max(0, self.depth - n)
 
     def push(self, n: int = 1) -> None:
-        """A convenience method to decrease the indentation of the formatter.
+        """A convenience method to increase the indentation of the formatter.
 
         Args:
-            n: Decrease the indentation depth by n.
+            n: Increase the indentation depth by n.
         """
         self.depth = self.depth + n
 

--- a/safedata_validator/logger.py
+++ b/safedata_validator/logger.py
@@ -119,7 +119,7 @@ class IndentFormatter(logging.Formatter):
         """A convenience method to decrease the indentation of the formatter.
 
         Args:
-            n: Decreease the indentation depth by n.
+            n: Decrease the indentation depth by n.
         """
 
         self.depth = max(0, self.depth - n)

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -292,7 +292,7 @@ class Summary:
                     extra={"join": non_none_failed_headers},
                 )
 
-        # Now we have warned about bad values, explicitly cast row keys to None to
+        # Now we have warned about bad values, explicitly cast row keys to string to
         # continue processing.
         self._rows = {str(rw[0]).lower(): rw[1:] for rw in rows}
 

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -272,15 +272,29 @@ class Summary:
 
         self._ncols = worksheet.max_column
 
-        # convert into dictionary using the lower cased first entry as the key
+        # convert into dictionary using the lower cased first entry as the key after
+        # checking for empty values (None) and non-string values.
         row_headers = IsString([r[0] for r in rows])
         if not row_headers:
-            LOGGER.error(
-                "Summary metadata fields column contains non text values :",
-                extra={"join": row_headers.failed},
-            )
+            # Check for None separately because seeing 'None' as a field key in the
+            # report is very confusing for end users.
+            if None in row_headers.failed:
+                LOGGER.error("Summary metadata fields column contains empty cells")
+                row_headers
 
-        self._rows = {rw[0].lower(): rw[1:] for rw in rows}
+            # Get other non-string headers.
+            non_none_failed_headers = [
+                hdr for hdr in row_headers.failed if hdr is not None
+            ]
+            if non_none_failed_headers:
+                LOGGER.error(
+                    "Summary metadata fields column contains non text values: ",
+                    extra={"join": non_none_failed_headers},
+                )
+
+        # Now we have warned about bad values, explicitly cast row keys to None to
+        # continue processing.
+        self._rows = {str(rw[0]).lower(): rw[1:] for rw in rows}
 
         # Check the minimal keys are expected - mandatory fields in mandatory blocks
         found, aliases = self._check_for_mandatory_fields()

--- a/test/test_field.py
+++ b/test/test_field.py
@@ -1627,7 +1627,8 @@ def test_GeoField_init(caplog, fixture_dataset, provide_ds_instance, expected_lo
             [111, 112, 113, 114, 115, 116],
             ((INFO, "Checking field geocoords"),),
         ),
-        # Bad inputs
+        # Bad inputs - non numeric, outside extents and no valid data at all to check
+        # updating of dataset extents.
         (
             "latitude",
             [1, "2", 3, 4, 5, 6],
@@ -1681,6 +1682,14 @@ def test_GeoField_init(caplog, fixture_dataset, provide_ds_instance, expected_lo
             "longitude",
             [111, 112, 113, 114, 115, 160],
             ((INFO, "Checking field geocoords"), (WARNING, "exceeds soft bounds")),
+        ),
+        (
+            "longitude",
+            ["111", "112", "113", "114", "115", "116"],
+            (
+                (INFO, "Checking field geocoords"),
+                (ERROR, "Field contains non-numeric data"),
+            ),
         ),
     ],
 )

--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -32,9 +32,10 @@ def test_logger(caplog, level, message, extra, depth, expected):
     # Capture _all_ logging events, not just WARNING and above
     caplog.set_level(DEBUG)
 
-    # Truncate any existing log messages
+    # Truncate any existing log messages and reset the depth
     LOG.seek(0)
     LOG.truncate()
+    FORMATTER.depth = 0
 
     # Emit the message
     FORMATTER.push(depth)

--- a/test/test_summary.py
+++ b/test/test_summary.py
@@ -15,7 +15,6 @@ from .conftest import log_check
 
 @pytest.fixture
 def fixture_summary(fixture_resources):
-
     return Summary(fixture_resources)
 
 
@@ -107,7 +106,6 @@ def fixture_summary(fixture_resources):
     ],
 )
 def test_authors(caplog, fixture_summary, alterations, should_log_error, expected_log):
-
     # Valid set of information
     input = {
         "author name": ("Orme, David",),
@@ -263,7 +261,6 @@ def test_authors(caplog, fixture_summary, alterations, should_log_error, expecte
     ],
 )
 def test_access(caplog, fixture_summary, row_data, should_log_error, expected_log):
-
     # Update valid to test error conditions and populate _rows
     # directly (bypassing .load() and need to pack in worksheet object
     fixture_summary._rows = row_data
@@ -304,7 +301,6 @@ def test_access(caplog, fixture_summary, row_data, should_log_error, expected_lo
     ],
 )
 def test_keywords(caplog, fixture_summary, alterations, should_log_error, expected_log):
-
     # Valid set of information
     input = {"keywords": ("abc", "def")}
 
@@ -388,7 +384,6 @@ def test_keywords(caplog, fixture_summary, alterations, should_log_error, expect
     ],
 )
 def test_permits(caplog, fixture_summary, alterations, should_log_error, expected_log):
-
     # Valid set of information
     input = {
         "permit type": ("research",),
@@ -444,7 +439,6 @@ def test_permits(caplog, fixture_summary, alterations, should_log_error, expecte
 def test_doi(
     caplog, fixture_summary, alterations, should_log_error, expected_log, do_val_doi
 ):
-
     # Valid set of information
     input = {"publication doi": ("https://doi.org/10.1098/rstb.2011.0049",)}
 
@@ -545,7 +539,6 @@ def test_doi(
     ],
 )
 def test_funders(caplog, fixture_summary, alterations, should_log_error, expected_log):
-
     # Valid set of information
     input = {
         "funding body": ("NERC",),
@@ -634,7 +627,6 @@ def test_funders(caplog, fixture_summary, alterations, should_log_error, expecte
 def test_temporal_extent(
     caplog, fixture_summary, alterations, should_log_error, expected_log
 ):
-
     # Valid set of information - openpyxl loads dates as datetimes but
     # the validation checks that these values are dates
     # (have no time information)
@@ -760,7 +752,6 @@ def test_temporal_extent(
 def test_geographic_extent(
     caplog, fixture_summary, alterations, should_log_error, expected_log
 ):
-
     # Valid set of information
     input = {"west": (116.75,), "east": (117.82,), "south": (4.50,), "north": (5.07,)}
 
@@ -827,7 +818,6 @@ def test_geographic_extent(
 def test_external_files(
     caplog, fixture_summary, alterations, should_log_error, expected_log
 ):
-
     # Valid set of information
     input = {
         "external file": ("BaitTrapImages.zip", "BaitTrapTransects.geojson"),
@@ -1192,10 +1182,27 @@ def test_load_valid_project_ids(
     argvalues=[
         pytest.param(
             False,
-            [["header1"], [23]],
+            [["title"], [None]],
             (
                 (INFO, "Checking Summary worksheet"),
-                (ERROR, "Summary metadata fields column contains non text values :"),
+                (ERROR, "Summary metadata fields column contains empty cells"),
+                (ERROR, "Missing mandatory metadata fields:"),
+                (ERROR, "Unknown metadata fields:"),
+                (INFO, "Loading core metadata"),
+                (ERROR, "No Core fields metadata found"),
+            ),
+            id="empty header",
+        ),
+        pytest.param(
+            False,
+            [["title"], [9]],
+            (
+                (INFO, "Checking Summary worksheet"),
+                (ERROR, "Summary metadata fields column contains non text values: "),
+                (ERROR, "Missing mandatory metadata fields:"),
+                (ERROR, "Unknown metadata fields:"),
+                (INFO, "Loading core metadata"),
+                (ERROR, "No Core fields metadata found"),
             ),
             id="non text header",
         ),


### PR DESCRIPTION
This PR:

* Fixes #86 by handling empty cells and non-string cells in Summary metadata fields more cleanly.
* Fixes #87 by checking for actual data in field `min` and `max` values before attempting to update extents.
* Fixes #91 by wrapping output in `report` method in `BaseField` subclasses with `FORMATTER` push and pop calls.