### PR TITLE
Implements the project database configuration

### DIFF
--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_build_local_gbif.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_build_local_gbif.txt
@@ -15,7 +15,7 @@ Build a local GBIF database.
 positional arguments:
   outdir                Location to create database file.
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
   -t TIMESTAMP, --timestamp TIMESTAMP
                         The time stamp of a database archive version to use.

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_build_local_ncbi.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_build_local_ncbi.txt
@@ -15,7 +15,7 @@ Build a local NCBI database.
 positional arguments:
   outdir                Location to create database file.
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
   -t TIMESTAMP, --timestamp TIMESTAMP
                         The time stamp of a database archive version to use.

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_server_post_metadata.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_server_post_metadata.txt
@@ -10,5 +10,5 @@ positional arguments:
   zenodo_json   Path to a Zenodo metadata file
   dataset_json  Path to a dataset metadata file
 
-options:
+optional arguments:
   -h, --help    show this help message and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_server_top.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_server_top.txt
@@ -15,7 +15,7 @@ positional arguments:
     post_metadata       Post dataset metadata to a safedata server
     update_gazetteer    Update the gazetteer data on safedata server
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
   -r RESOURCES, --resources RESOURCES
                         Path to a safedata_validator resource configuration

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_server_update_gazetteer.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_server_update_gazetteer.txt
@@ -9,5 +9,5 @@ positional arguments:
   gazetteer_json    Path to a gazetteer geojson file
   location_aliases  Path to a CSV of location aliases
 
-options:
+optional arguments:
   -h, --help        show this help message and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_validate.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_validate.txt
@@ -1,6 +1,6 @@
 cl_prompt $ safedata_validate -h
-usage: safedata_validate [-h] [-p VALID_PID] [-r RESOURCES] [--validate_doi]
-                         [--chunk_size CHUNK_SIZE] [--version]
+usage: safedata_validate [-h] [-r RESOURCES] [--validate_doi]
+                         [--chunk_size CHUNK_SIZE] [-o OUTPUT] [--version]
                          filename
 
 Validate a dataset using a command line interface.
@@ -25,13 +25,8 @@ Validate a dataset using a command line interface.
 positional arguments:
   filename              Path to the Excel file to be validated.
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
-  -p VALID_PID, --project_id VALID_PID
-                        If provided, check that the project ID within the file
-                        matches this integer. Multiple values can be provided
-                        to generate a set of valid IDs. This option only makes
-                        sense to use if your organisation uses project IDs.
   -r RESOURCES, --resources RESOURCES
                         A path to a resources configuration file
   --validate_doi        Check the validity of any publication DOIs, provided
@@ -39,4 +34,7 @@ options:
   --chunk_size CHUNK_SIZE
                         Data are loaded from worksheets in chunks: the number
                         of rows in a chunk is set by this argument
+  -o OUTPUT, --output OUTPUT
+                        Save the validation report to a file, not print to the
+                        console.
   --version             show program's version number and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_amend_metadata.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_amend_metadata.txt
@@ -14,5 +14,5 @@ positional arguments:
   zenodo_json_update
                 Path to an updated Zenodo metadata file
 
-options:
+optional arguments:
   -h, --help    show this help message and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_create_deposit.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_create_deposit.txt
@@ -9,7 +9,7 @@ When successful, the function downloads and saves a JSON file containing the
 resulting Zenodo deposit metadata. This file is used as an input to other
 subcommands that work with an existing deposit.
 
-options:
+optional arguments:
   -h, --help    show this help message and exit
   -c CONCEPT_ID, --concept_id CONCEPT_ID
                 A Zenodo concept ID

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_delete_file.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_delete_file.txt
@@ -9,5 +9,5 @@ positional arguments:
   zenodo_json  Path to a Zenodo metadata file for the deposit to discard
   filename     The name of the file to delete
 
-options:
+optional arguments:
   -h, --help   show this help message and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_discard_deposit.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_discard_deposit.txt
@@ -8,5 +8,5 @@ removed from Zenodo.
 positional arguments:
   zenodo_json  Path to a Zenodo metadata file for the deposit to discard
 
-options:
+optional arguments:
   -h, --help   show this help message and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_generate_html.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_generate_html.txt
@@ -11,5 +11,5 @@ positional arguments:
   zenodo_json   Path to a Zenodo metadata file
   dataset_json  Path to a dataset metadata file
 
-options:
+optional arguments:
   -h, --help    show this help message and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_generate_xml.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_generate_xml.txt
@@ -10,7 +10,7 @@ positional arguments:
   zenodo_json   Path to a Zenodo metadata file
   dataset_json  Path to a dataset metadata file
 
-options:
+optional arguments:
   -h, --help    show this help message and exit
   -l LINEAGE_STATEMENT, --lineage-statement LINEAGE_STATEMENT
                 Path to a text file containing a lineage statement

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_get_deposit.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_get_deposit.txt
@@ -7,5 +7,5 @@ Download the Zenodo metadata for a deposit and print out summary information.
 positional arguments:
   zenodo_id   An ID for an existing Zenodo deposit
 
-options:
+optional arguments:
   -h, --help  show this help message and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_maintain_ris.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_maintain_ris.txt
@@ -14,5 +14,5 @@ positional arguments:
               exists, it is assumed to be RIS file to update with any new
               records not already included in the file.
 
-options:
+optional arguments:
   -h, --help  show this help message and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_publish_deposit.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_publish_deposit.txt
@@ -12,5 +12,5 @@ before finally publishing.
 positional arguments:
   zenodo_json  Path to a Zenodo metadata file
 
-options:
+optional arguments:
   -h, --help   show this help message and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_show_config.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_show_config.txt
@@ -5,5 +5,5 @@ usage: safedata_zenodo [-h] [-r RESOURCES] [-q] SUBCOMMAND ... show_config
 Loads the safedata_validator configuration file, displays the config setup
 being used for safedata_zenodo and then exits.
 
-options:
+optional arguments:
   -h, --help  show this help message and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_sync_local_dir.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_sync_local_dir.txt
@@ -23,7 +23,7 @@ positional arguments:
   datadir       The path to a local directory containing an existing safedata
                 directory or an empty folder in which to create one
 
-options:
+optional arguments:
   -h, --help    show this help message and exit
   --not-just-xlsx
                 Should large non-xlsx files also be downloaded.

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_top.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_top.txt
@@ -58,7 +58,7 @@ positional arguments:
     show_config
                 Report the config being used and exit
 
-options:
+optional arguments:
   -h, --help    show this help message and exit
   -r RESOURCES, --resources RESOURCES
                 Path to a safedata_validator resource configuration file

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_upload_file.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_upload_file.txt
@@ -10,7 +10,7 @@ positional arguments:
   zenodo_json   Path to a Zenodo metadata JSON for the deposit
   filepath      The path to the file to be uploaded
 
-options:
+optional arguments:
   -h, --help    show this help message and exit
   --zenodo_filename ZENODO_FILENAME
                 An optional alternative file name to be used on Zenodo

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_upload_metadata.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_upload_metadata.txt
@@ -9,5 +9,5 @@ positional arguments:
   zenodo_json   Path to a Zenodo metadata file
   dataset_json  Path to a dataset metadata file
 
-options:
+optional arguments:
   -h, --help    show this help message and exit

--- a/docs/data_managers/install/build_local_gbif.md
+++ b/docs/data_managers/install/build_local_gbif.md
@@ -26,6 +26,32 @@ include "data_managers/command_line_tools/command_line_usage/safedata_build_loca
 %}
 ```
 
+You will need to provide an output directory for the database and then use the command:
+
+```sh
+safedata_build_local_gbif outdir
+```
+
+This should result in the following output:
+
+```txt
+- Downloading GBIF data to: /path/to/tempdir
+    - Checking for version with timestamp 2023-08-28
+    - Downloading simple.txt.gz
+100%|████████████████████████████████████████████| 466M/466M [00:05<00:00, 92.2MB/s]
+    - Downloading simple-deleted.txt.gz
+100%|████████████████████████████████████████████| 90.8M/90.8M [00:00<00:00, 96.2MB/s]
+- Building GBIF backbone database in: /path/to/outdir/gbif_backbone_2023-08-28.sqlite
+    - Timestamp table created
+    - Backbone table created
+    - Adding core backbone taxa
+7746724it [03:31, 36688.61it/s]
+    - Adding deleted taxa
+1711901it [00:42, 40470.91it/s]
+    - Creating database indexes
+    - Removing downloaded files
+```
+
 Once you have an SQLite3 backbone database, you will then need to edit the
 `gbif_database` entry in your [configuration file](configuration.md) to provide
 the path to your new SQLite file.

--- a/docs/data_managers/install/build_local_ncbi.md
+++ b/docs/data_managers/install/build_local_ncbi.md
@@ -26,6 +26,35 @@ include "data_managers/command_line_tools/command_line_usage/safedata_build_loca
 %}
 ```
 
+You will need to provide an output directory for the database and then use the command:
+
+```sh
+safedata_build_local_ncbi outdir
+```
+
+This should result in the following output:
+
+```txt
+- Downloading NCBI data to: /path/to/tempdir
+    - Connecting to FTP server
+    - Using most recent archive: 2023-11-01
+    - Downloading taxonomy to: /path/to/tempdir/taxdmp_2023-11-01.zip
+100%|███████████████████████████████████████████| 60.5M/60.5M [00:03<00:00, 16.9MB/s]
+- Building GBIF backbone database in: /path/to/outdir/ncbi_taxonomy_2023-11-01.sqlite
+    - Timestamp table created
+    - Creating nodes table
+    - Populating nodes table from nodes.dmp
+2535034it [00:27, 93695.95it/s]
+    - Creating names table
+    - Populating names table from names.dmp
+3914203it [00:31, 123281.67it/s]
+    - Creating merge table
+    - Populating merge table from merged.dmp
+74501it [00:00, 155486.74it/s]
+    - Creating database indexes
+    - Removing downloaded archive
+```
+
 Once you have an SQLite3 backbone database, you will then need to edit the
 `gbif_database` entry in your [configuration file](configuration.md) to provide
 the path to your new SQLite file.

--- a/docs/data_managers/install/configuration.md
+++ b/docs/data_managers/install/configuration.md
@@ -133,13 +133,14 @@ provided to validate datasets.
 
 **The `project_database` element**
 
-: The project database element is an optional configuration option, that allows datasets
+: The project database element is an optional configuration setting that allows datasets
   to be grouped into projects. If you want to use projects then you will need to create
   a CSV file containing at least `project_id` and `title` fields, although you can add
   other fields if you want.
 
     The project database can be updated to add new projects and change titles and other 
-    details but the project ID values themselves must be persistent
+    details but you must not change or delete existing Project IDs once they have been
+    created - a given project ID must always refer to the same project.
 
     !!! Warning
         Each deployment of the `safedata` system will have to make a **binding choice** 

--- a/docs/data_managers/install/configuration.md
+++ b/docs/data_managers/install/configuration.md
@@ -14,7 +14,7 @@ gbif_database = /path/to/local/backbone.sqlite3
 ncbi_database = /path/to/local/ncbi_database.sqlite3
 gazetteer = /path/to/gazeteer.geojson
 location_aliases = /path/to/location_aliases.csv
-use_project_ids = True
+project_database = /path/to/project_database.csv
 
 [extents]
 temporal_soft_extent = 2002-02-02, 2030-01-31
@@ -131,21 +131,21 @@ provided to validate datasets.
 : These elements provide the paths to the [location database](gazetteer.md) for the
   project.
 
-**The `use_project_ids` element**
+**The `project_database` element**
 
-: The `safedata` system was initially developed as part of the SAFE project, which
-  organises datasets into projects. Each project is identified using a unique
-  identification number, and each dataset is associated with one or more projects using
-  these project ID numbers. We anticipate that other deployments of the `safedata`
-  system may not wish to organise datasets in this manner. If so, the checking of
-  project IDs can be turned off by setting the `use_project_ids` option  to `False`.
-  With this option off, datasets will **fail validation** if they contain project IDs.
+: The project database element is an optional configuration option, that allows datasets
+  to be grouped into projects. If you want to use projects then you will need to create
+  a CSV file containing at least `project_id` and `title` fields, although you can add
+  other fields if you want.
+
+    The project database can be updated to add new projects and change titles and other 
+    details but the project ID values themselves must be persistent
 
     !!! Warning
-        Each deployment of the `safedata` system will have to make a choice of whether
-        or not to organise datasets into project. Once this choice has been made it will
-        be binding. As such, this option should only be changed by the relevant data 
-        manager during the initial setup of the data system.
+        Each deployment of the `safedata` system will have to make a **binding choice** 
+        of whether or not to organise datasets into project. The data manager for a
+        project will need to make this decision during the initial configuration of a
+        data system.
 
 **The `extents` element**
 

--- a/docs/data_providers/data_format/summary.md
+++ b/docs/data_providers/data_format/summary.md
@@ -52,10 +52,6 @@ tbody td:first-child {
 This block provides a set of core details for the dataset. You can only provide
 a single value for each field.
 
-* **Project ID**: This is only used if the organisation you are uploading to uses
-  projects to group datasets. If they are, then you should obtain relevant project IDs
-  from the organisation's data manager and add them in your Summary worksheet. Older
-  datasets may use the field name as `SAFE Project ID` but this is deprecated.
 * **Title**: This should be a short informative title for the dataset: it will
   be used as the public title for the dataset so make sure it is clear and
   grammatical!
@@ -66,9 +62,25 @@ a single value for each field.
 
 |                 |                                   |  |  |
 |-----------------|-----------------------------------|--|--|
-| Project ID      | 1                                 |  |  |
 | Title           | Example data for the safedata system |  |  |
 | Description     | This is an example dataset.       |  |  |
+
+## The Project ID block
+
+!!! Warning "Possibly mandatory block"
+    This block will be mandatory if the data collection you are publishing to uses
+    projects to group datasets. If they are, then you should obtain relevant project IDs
+    from the organisation's data manager and add them in this block.
+
+This simple block provides project ID codes for the dataset.
+
+* **Project ID**: Provide the integer project id codes for the research project that
+  this dataset is associated with. Older datasets may use the field name as `SAFE
+  Project ID` but this is deprecated.
+
+|                 |                                   |  |  |
+|-----------------|-----------------------------------|--|--|
+| Project ID      | 1                                 |  |  |
 
 ## The access block
 

--- a/safedata_validator/entry_points.py
+++ b/safedata_validator/entry_points.py
@@ -76,17 +76,7 @@ def _safedata_validator_cli():
     parser = argparse.ArgumentParser(description=desc, formatter_class=fmt)
 
     parser.add_argument("filename", help="Path to the Excel file to be validated.")
-    parser.add_argument(
-        "-p",
-        "--project_id",
-        default=None,
-        type=int,
-        action="append",
-        help="If provided, check that the project ID within the file matches this "
-        "integer. Multiple values can be provided to generate a set of valid IDs. This "
-        "option only makes sense to use if your organisation uses project IDs.",
-        dest="valid_pid",
-    )
+
     parser.add_argument(
         "-r",
         "--resources",
@@ -138,7 +128,6 @@ def _safedata_validator_cli():
     ds = Dataset(resources=Resources(args.resources))
     ds.load_from_workbook(
         filename=args.filename,
-        valid_pid=args.valid_pid,
         validate_doi=args.validate_doi,
         chunk_size=args.chunk_size,
     )

--- a/safedata_validator/field.py
+++ b/safedata_validator/field.py
@@ -117,7 +117,6 @@ class Dataset:
         self,
         filename: str,
         validate_doi: bool = False,
-        valid_pid: Optional[List[int]] = None,
         chunk_size: int = 1000,
         console_log: bool = True,
     ) -> None:
@@ -135,8 +134,6 @@ class Dataset:
         Args:
             filename: A path to the workbook containing the dataset
             validate_doi: Should DOIs in the dataset summary be validated
-            valid_pid: An optional list of valid values for the project ID
-                field in the dataset summary.
             chunk_size: Data is read from worksheets in chunks of rows - this
                 argument sets the size of that chunk.
             console_log: Suppress command line logging.
@@ -165,7 +162,6 @@ class Dataset:
                 wb["Summary"],
                 wb.sheetnames,
                 validate_doi=validate_doi,
-                valid_pid=valid_pid,
             )
         else:
             # No summary is impossible - so an error and no dataworksheets

--- a/safedata_validator/logger.py
+++ b/safedata_validator/logger.py
@@ -1,29 +1,31 @@
 """This submodule extends the standard logging setup to provide extra functionality
 and to expose some global logging objects for use throughout the code.
 
-1. The :class:`logging.LogRecordFactory` is updated so that new records include a custom
-   ``levelcode`` attribute to visually indicate log record severity in validation
+1. The `logging.LogRecordFactory` is updated so that new records include a custom
+   `levelcode` attribute to visually indicate log record severity in validation
    reports. 
 
-2. The :func:`~safedata_validator.logging.IndentFormatter` class then extends
+2. The [IndentFormatter][safedata_validator.logger.IndentFormatter] class then extends
    :class:`logging.Formatter` to provide compact messages with variable indentation to
    show nested sections of the validation process using the level codes as visual cues
    for problems.
 
-3. The submodule then defines two ``CounterHandler`` classes which subclass
-   :class:`logging.StreamHandler` and :class:`logging.FileHandler`. Both extend the
-   basic handlers to add attributes that keep track of counts of different classes of
-   records emitted through the handler.
+3. The submodule then defines two `CounterHandler` classes which subclass
+   `logging.StreamHandler` and `logging.FileHandler`. Both extend the basic handlers to
+   add attributes that keep track of counts of different classes of records emitted
+   through the handler.
 
-4. The submodule provides the :func:`~safedata_validator.logging.use_file_logging` and
-   :func:`~safedata_validator.logging.use_stream_logging` to assign handlers to be used
-   in the validation process. The :func:`~safedata_validator.logging.get_handler`
-   function is then used as a convenience function to retrieve the current handler to
-   access counts of the various emitted records.
+4. The submodule provides the functions
+   [use_file_logging][safedata_validator.logger.use_file_logging] and
+   [use_stream_logging][safedata_validator.logger.use_stream_logging] to assign
+   handlers to be used in the validation process. The
+   [get_handler][safedata_validator.logger.get_handler] function is then used as a
+   convenience function to retrieve the current handler to access counts of the various
+   emitted records.
 
-5. The :func:`~safedata_validator.logging.log_and_raise` functions and
-   :func:`~safedata_validator.logging.loggerinfo_push_pop` are convenience functions to
-   minimise logging boilerplate code within the package.
+5. The functions [log_and_raise][safedata_validator.logger.log_and_raise] and
+   [loggerinfo_push_pop][safedata_validator.logger.loggerinfo_push_pop] are convenience
+   functions to minimise logging boilerplate code within the package.
 """  # noqa D415
 
 import logging

--- a/safedata_validator/resources.py
+++ b/safedata_validator/resources.py
@@ -230,7 +230,6 @@ class Resources:
         self.location_aliases: dict[str, str] = dict()
         # Projects are a dictionary keying project ID to a title.
         self.projects: dict[int, str] = dict()
-        self.use_project_ids = False  # TODO delete this.
 
         # Validate the resources
         self._validate_gazetteer()

--- a/safedata_validator/resources.py
+++ b/safedata_validator/resources.py
@@ -1,15 +1,17 @@
 """The `safedata_validator` package needs access to some local resources and
 configuration to work. The core resources for file validation are:
 
--   gazetteer: A path to a GeoJSON formatted gazetteer of known locations and their
+- gazetteer: A path to a GeoJSON formatted gazetteer of known locations and their
     details.
 
--   location_aliases: A path to a CSV file containing known aliases of the location
+- location_aliases: A path to a CSV file containing known aliases of the location
     names provided in the gazetteer.
 
--   gbif_database: The path to a local SQLite copy of the GBIF backbone database.
+- gbif_database: The path to a local SQLite copy of the GBIF backbone database.
 
--   ncbi_database: The path to a local SQLite copy of the NCBI database files.
+- ncbi_database: The path to a local SQLite copy of the NCBI database files.
+
+- project_database: Optionally, a path to a CSV file providing valid project IDs.
 
 The [Resources][safedata_validator.resources.Resources] class is used to locate and
 validate these resources, and then provide those validated resources to other components
@@ -29,7 +31,7 @@ import sqlite3
 from csv import DictReader
 from csv import Error as csvError
 from datetime import date
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import appdirs
 import simplejson
@@ -52,7 +54,7 @@ CONFIGSPEC = {
     "location_aliases": "string()",
     "gbif_database": "string()",
     "ncbi_database": "string()",
-    "use_project_ids": "boolean(default=True)",
+    "project_database": "string(default=None)",
     "extents": {
         "temporal_soft_extent": "date_list(min=2, max=2, default=None)",
         "temporal_hard_extent": "date_list(min=2, max=2, default=None)",
@@ -148,7 +150,7 @@ class Resources:
         location_aliases: The path to the location_aliases file
         gbif_database: The path to the GBIF database file
         ncbi_database: The path to the NCBI database file
-        use_project_ids: Whether this organisation uses project IDs or not
+        project_database: An optional path to a database of valid project IDs
         valid_locations: The locations defined in the locations file
         location_aliases: Location aliases defined in the locations file
         extents: A DotMap of extent data
@@ -206,9 +208,13 @@ class Resources:
         self.localias_path = config_loaded.location_aliases
         self.gbif_database = config_loaded.gbif_database
         self.ncbi_database = config_loaded.ncbi_database
+        self.project_database = (
+            None
+            if config_loaded.project_database == ""
+            else config_loaded.project_database
+        )
         self.config_type = config_loaded.config_type
         self.config_source = config_loaded.config_source
-        self.use_project_ids = config_loaded.use_project_ids
 
         self.extents = config_loaded.extents
         self.zenodo = config_loaded.zenodo
@@ -222,12 +228,16 @@ class Resources:
         self.valid_location: dict[str, list[float]] = dict()
         # Location aliases is a dictionary keying a string to a key in valid locations
         self.location_aliases: dict[str, str] = dict()
+        # Projects are a dictionary keying project ID to a title.
+        self.projects: dict[int, str] = dict()
+        self.use_project_ids = False  # TODO delete this.
 
         # Validate the resources
         self._validate_gazetteer()
         self._validate_location_aliases()
         self._validate_gbif()
         self._validate_ncbi()
+        self._validate_projects()
 
     @staticmethod
     def _load_config(config: Union[str, list, dict], cfg_type: str) -> DotMap:
@@ -378,6 +388,57 @@ class Resources:
         self.ncbi_timestamp = validate_taxon_db(
             self.ncbi_database, "NCBI", ["nodes", "merge", "names"]
         )
+
+    def _validate_projects(self) -> None:
+        """Validate and load a project database.
+
+        This private function checks whether a project_database path: exists, is a CSV
+        file, and contains project data. It populates the instance ``project_id``
+        attribute.
+        """
+
+        if self.project_database is None:
+            LOGGER.info("No project database configured")
+            return
+
+        LOGGER.info(f"Validating project database: {self.project_database}")
+
+        # Now check to see whether the project database behaves as expected
+        try:
+            dictr = DictReader(open(self.project_database, mode="r"))
+        except FileNotFoundError:
+            log_and_raise("Project database file not found", FileNotFoundError)
+        except IsADirectoryError:
+            log_and_raise("Project database path is a directory", IsADirectoryError)
+
+        # Simple test for structure - field names only parsed when called, and this can
+        # throw errors with bad file formats.
+        try:
+            if not dictr.fieldnames:
+                log_and_raise("Project database file is empty", ValueError)
+            else:
+                fieldnames = set(dictr.fieldnames)
+        except (UnicodeDecodeError, csvError):
+            log_and_raise(
+                "Project database file not readable as a CSV file with valid headers",
+                ValueError,
+            )
+
+        required_names = set(["project_id", "title"])
+        if required_names.intersection(fieldnames) != required_names:
+            log_and_raise(
+                "Project database file does not contain project_id and title headers.",
+                ValueError,
+            )
+
+        # Load the valid project ids
+        try:
+            self.projects = {int(prj["project_id"]): str(prj["title"]) for prj in dictr}
+        except ValueError:
+            log_and_raise(
+                "Project database file values not integer IDs and text titles.",
+                ValueError,
+            )
 
 
 def validate_taxon_db(db_path: str, db_name: str, tables: list[str]) -> str:

--- a/safedata_validator/resources.py
+++ b/safedata_validator/resources.py
@@ -397,7 +397,7 @@ class Resources:
         """
 
         if self.project_database is None:
-            LOGGER.info("No project database configured")
+            LOGGER.info("Configuration does not use project IDs.")
             return
 
         LOGGER.info(f"Validating project database: {self.project_database}")

--- a/safedata_validator/resources.py
+++ b/safedata_validator/resources.py
@@ -404,7 +404,7 @@ class Resources:
 
         # Now check to see whether the project database behaves as expected
         try:
-            dictr = DictReader(open(self.project_database, mode="r"))
+            dictr = DictReader(open(self.project_database, mode="r", encoding="UTF-8"))
         except FileNotFoundError:
             log_and_raise("Project database file not found", FileNotFoundError)
         except IsADirectoryError:
@@ -417,11 +417,11 @@ class Resources:
                 log_and_raise("Project database file is empty", ValueError)
             else:
                 fieldnames = set(dictr.fieldnames)
-        except (UnicodeDecodeError, csvError):
-            log_and_raise(
-                "Project database file not readable as a CSV file with valid headers",
-                ValueError,
+        except (UnicodeDecodeError, csvError) as excep:
+            LOGGER.critical(
+                "Project database file not readable as a CSV file with valid headers"
             )
+            raise excep
 
         required_names = set(["project_id", "title"])
         if required_names.intersection(fieldnames) != required_names:

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -93,63 +93,64 @@ class Summary:
     Args:
         resources: An instance of Resources providing the safedata_validator
             configuration.
-
-    Attributes:
-        fields: A dictionary setting the expected metadata fields for summary tables.
-        project_id: An integer project ID code
-        title: A string giving the dataset title.
-        description: A string giving a description of the dataset
-        access: A dictionary giving access metadata.
-        authors: A list of dictionaries of author metadata.
-        permits: A list of dictionaries of research permit metadata.
-        publication_doi: A list of DOIs associated with the dataset.
-        funders: A list of dictionaries of funder metadata.
-        keywords: A list of keyword strings.
-        temporal_extent: Extent instance for the temporal extent of the Dataset.
-        latitudinal_extent: Extent instance for the latitudinal extent of the Dataset.
-        longitudinal_extent: Extent instance for the longitudinal extent of the Dataset.
-        external_files: A list of dictionaries of external file metadata.
-        data_worksheets: A list of dictionaries of data tables in the Dataset.
-        n_errors: A count of the number of errors from loading a summary table.
-        validate_doi: A boolean flag indicating whether DOI values should be validated.
     """
 
     def __init__(self, resources: Resources) -> None:
-        self.project_id = None
-        self.title = None
-        self.description = None
-        self.access = None
-        self.authors = None
-        self.permits = None
+        self.title: str
+        """A string giving the dataset title."""
+        self.description: str
+        """A string giving a description of the dataset."""
+        self.access: dict
+        """A dictionary giving access metadata."""
+        self.authors: list[dict]
+        "A list of dictionaries of author metadata."
+        self.permits: list[dict]
+        """A list of dictionaries of research permit metadata."""
         self.publication_doi = None
+        """A list of DOIs associated with the dataset."""
         self.funders = None
-        self.keywords = None
-        self.temporal_extent = Extent(
+        """A list of dictionaries of funder metadata."""
+        self.keywords: list[str]
+        """A list of keyword strings."""
+        self.temporal_extent: Extent = Extent(
             "temporal extent",
             (datetime.date,),
             hard_bounds=resources.extents.temporal_hard_extent,
             soft_bounds=resources.extents.temporal_soft_extent,
         )
-        self.latitudinal_extent = Extent(
+        """Extent instance for the temporal extent of the Dataset."""
+        self.latitudinal_extent: Extent = Extent(
             "latitudinal extent",
             (float, int),
             hard_bounds=resources.extents.latitudinal_hard_extent,
             soft_bounds=resources.extents.latitudinal_soft_extent,
         )
-        self.longitudinal_extent = Extent(
+        """Extent instance for the latitudinal extent of the Dataset."""
+        self.longitudinal_extent: Extent = Extent(
             "longitudinal extent",
             (float, int),
             hard_bounds=resources.extents.longitudinal_hard_extent,
             soft_bounds=resources.extents.longitudinal_soft_extent,
         )
-        self.external_files = None
+        """Extent instance for the longitudinal extent of the Dataset."""
+        self.external_files: Optional[list[dict]] = None
+        """A list of dictionaries of external file metadata."""
         self.data_worksheets: list[Worksheet] = []
+        """A list of dictionaries of data tables in the Dataset."""
 
         self._rows: dict = {}
+        """A private attribute holding the row data for the summary."""
         self._ncols: int
+        """A private attribute holding the total number of columns in the summary."""
         self.n_errors: int = 0
+        """The number of validation errors found in the summary."""
         self.projects: dict[int, str] = resources.projects
+        """A dictionary of valid project data."""
+        self.project_id: Optional[list[int]] = None
+        """A list of project ID codes, if project IDs are configured."""
+
         self.validate_doi = False
+        """A boolean flag indicating whether DOI values should be validated."""
 
         # Define the blocks and fields in the summary - note that the project ids block
         # is mandatory if a project database has been populated.
@@ -269,6 +270,7 @@ class Summary:
                 singular=False,
             ),
         )
+        """A dictionary setting the summary blocks that can be present."""
 
     @loggerinfo_push_pop("Checking Summary worksheet")
     def load(
@@ -891,6 +893,7 @@ class Summary:
             )
 
         self.project_id = valid_proj_ids
+        LOGGER.info("Valid project ids provided: ", extra={"join": valid_proj_ids})
 
 
 def load_rows_from_worksheet(worksheet: Worksheet) -> list[tuple]:

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -29,19 +29,6 @@ RE_EMAIL = re.compile(r"\S+@\S+\.\S+")
 RE_NAME = re.compile(r"[^,]+,[ ]?[^,]+")
 RE_CONTAINS_WSPACE = re.compile(r"\s")
 
-# Class attribute to define the metadata that may be present.
-# These are defined in blocks of related rows described in 4-tuples:
-#  0: a list of tuples giving the rows in the block:
-#     * row header key
-#     * mandatory within the block
-#     * 'internal' name - also maps to Zenodo fields
-#     * accepted types
-#     * list of aliases for the fieldname (this generally will be blank)
-#  1: is the block mandatory (bool)
-#  2: the title of the block for the logger
-#  3: should there be only one record (bool)
-#
-
 
 @dataclass
 class SummaryField:

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -313,11 +313,10 @@ class Summary:
         self._rows = {str(rw[0]).lower(): rw[1:] for rw in rows}
 
         # Validate the keys found in the summary table
-        found: set[str] = set(self._rows.keys())
-        self._validate_keys(found=found)
+        self._validate_keys()
 
         # Now process the field blocks
-        self._load_core(found)
+        self._load_core()
         self._load_access_details()
         self._load_authors()
         self._load_keywords()
@@ -336,14 +335,15 @@ class Summary:
         else:
             LOGGER.info("Summary formatted correctly")
 
-    def _validate_keys(self, found: set[str]) -> None:
+    def _validate_keys(self) -> None:
         """Validate the summary keys recovered.
 
         This function checks that the keys in a summary table include the minimum set of
         mandatory fields in mandatory blocks and that all found keys are known.
         """
 
-        # Find all required fields and known fields
+        # Populate found, required and known field keys
+        found: set[str] = set(self._rows.keys())
         required: set[str] = set()
         known: set[str] = set()
 
@@ -814,7 +814,7 @@ class Summary:
         self.access = access
 
     @loggerinfo_push_pop("Loading core metadata")
-    def _load_core(self, found):
+    def _load_core(self):
         """Load the core block.
 
         Provides summary validation specific to the core block.

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -111,7 +111,6 @@ class Summary:
         external_files: A list of dictionaries of external file metadata.
         data_worksheets: A list of dictionaries of data tables in the Dataset.
         n_errors: A count of the number of errors from loading a summary table.
-        valid_pid: A list of valid project ID values.
         validate_doi: A boolean flag indicating whether DOI values should be validated.
     """
 

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -6,6 +6,7 @@ methods for loading the summary data from file.
 
 import datetime
 import re
+from dataclasses import dataclass
 from typing import Optional, Union
 
 import requests  # type: ignore
@@ -27,6 +28,55 @@ RE_ORCID = re.compile(r"[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]")
 RE_EMAIL = re.compile(r"\S+@\S+\.\S+")
 RE_NAME = re.compile(r"[^,]+,[ ]?[^,]+")
 RE_CONTAINS_WSPACE = re.compile(r"\s")
+
+# Class attribute to define the metadata that may be present.
+# These are defined in blocks of related rows described in 4-tuples:
+#  0: a list of tuples giving the rows in the block:
+#     * row header key
+#     * mandatory within the block
+#     * 'internal' name - also maps to Zenodo fields
+#     * accepted types
+#     * list of aliases for the fieldname (this generally will be blank)
+#  1: is the block mandatory (bool)
+#  2: the title of the block for the logger
+#  3: should there be only one record (bool)
+#
+
+
+@dataclass
+class SummaryField:
+    """Summary field details.
+
+    This dataclass records details of summary fields within a block:
+
+    * the expected key in the first column of the summary table,
+    * whether a field is mandatory within the block,
+    * an optional internal name to be used for the key,
+    * the acceptable types that values in the field can have.
+    """
+
+    key: str
+    mandatory: bool
+    internal: Optional[str]
+    types: Union[type, tuple[type, ...]]
+
+
+@dataclass
+class SummaryBlock:
+    """Summary block details.
+
+    This dataclass records details of a block of related summary fields:
+
+    * The list of fields in the block
+    * Whether the block is mandatory
+    * The title for the block, used in reporting
+    * If the block should only accept a single record.
+    """
+
+    fields: list[SummaryField]
+    mandatory: bool
+    title: str
+    singular: bool
 
 
 class Summary:
@@ -96,130 +146,122 @@ class Summary:
         )
         self.external_files = None
         self.data_worksheets: list[Worksheet] = []
-        self.use_project_ids = resources.use_project_ids
 
         self._rows: dict = {}
         self._ncols: int
         self.n_errors: int = 0
-        self.valid_pid: Optional[list[int]] = None
+        self.projects: dict[int, str] = resources.projects
         self.validate_doi = False
 
-        # Class attribute to define the metadata that may be present.
-        # These are defined in blocks of related rows described in 4-tuples:
-        #  0: a list of tuples giving the rows in the block:
-        #     * row header key
-        #     * mandatory within the block
-        #     * 'internal' name - also maps to Zenodo fields
-        #     * accepted types
-        #     * list of aliases for the fieldname (this generally will be blank)
-        #  1: is the block mandatory (bool)
-        #  2: the title of the block for the logger
-        #  3: should there be only one record (bool)
-        #
-        # Each entry in the list of rows provides the row header that appears
-        # in the summary sheet, if that field is mandatory within the set and
-        # an internal field name, if needed in the code or by Zenodo.
+        # Define the blocks and fields in the summary
 
-        self.fields: dict[str, tuple[list, bool, str, bool]] = dict(
-            core=(
-                [
-                    (
-                        "project id",
-                        self.use_project_ids,
-                        "pid",
-                        int,
-                        ["safe project id"],
+        self.fields: dict[str, SummaryBlock] = dict(
+            core=SummaryBlock(
+                fields=[
+                    SummaryField("safe project id", False, None, int),
+                    SummaryField("project id", False, None, int),
+                    SummaryField("title", True, None, str),
+                    SummaryField("description", True, None, str),
+                ],
+                mandatory=True,
+                title="Core fields",
+                singular=True,
+            ),
+            access=SummaryBlock(
+                fields=[
+                    SummaryField("access status", True, "access", str),
+                    SummaryField(
+                        "embargo date", False, "embargo_date", datetime.datetime
                     ),
-                    ("title", True, None, str, []),
-                    ("description", True, None, str, []),
+                    SummaryField("access conditions", False, "access_conditions", str),
                 ],
-                True,
-                "Core fields",
-                True,
+                mandatory=True,
+                title="Access details",
+                singular=True,
             ),
-            access=(
-                [
-                    ("access status", True, "access", str, []),
-                    ("embargo date", False, "embargo_date", datetime.datetime, []),
-                    ("access conditions", False, "access_conditions", str, []),
-                ],
-                True,
-                "Access details",
-                True,
+            keywords=SummaryBlock(
+                fields=[SummaryField("keywords", True, None, str)],
+                mandatory=True,
+                title="Keywords",
+                singular=False,
             ),
-            keywords=([("keywords", True, None, str, [])], True, "Keywords", False),
-            doi=([("publication doi", True, None, str, [])], False, "DOI", False),
-            date=(
-                [
-                    ("start date", True, None, datetime.datetime, []),
-                    ("end date", True, None, datetime.datetime, []),
-                ],
-                False,
-                "Date Extents",
-                True,
+            doi=SummaryBlock(
+                fields=[SummaryField("publication doi", True, None, str)],
+                mandatory=False,
+                title="DOI",
+                singular=False,
             ),
-            geo=(
-                [
-                    ("west", True, None, float, []),
-                    ("east", True, None, float, []),
-                    ("south", True, None, float, []),
-                    ("north", True, None, float, []),
+            date=SummaryBlock(
+                fields=[
+                    SummaryField("start date", True, None, datetime.datetime),
+                    SummaryField("end date", True, None, datetime.datetime),
                 ],
-                False,
-                "Geographic Extents",
-                True,
+                mandatory=False,
+                title="Date Extents",
+                singular=True,
             ),
-            authors=(
-                [
-                    ("author name", True, "name", str, []),
-                    ("author affiliation", False, "affiliation", str, []),
-                    ("author email", False, "email", str, []),
-                    ("author orcid", False, "orcid", str, []),
+            geo=SummaryBlock(
+                fields=[
+                    SummaryField("west", True, None, float),
+                    SummaryField("east", True, None, float),
+                    SummaryField("south", True, None, float),
+                    SummaryField("north", True, None, float),
                 ],
-                True,
-                "Authors",
-                False,
+                mandatory=False,
+                title="Geographic Extents",
+                singular=True,
             ),
-            funding=(
-                [
-                    ("funding body", True, "body", str, []),
-                    ("funding type", True, "type", str, []),
-                    ("funding reference", False, "ref", (str, int, float), []),
-                    ("funding link", False, "url", str, []),
+            authors=SummaryBlock(
+                fields=[
+                    SummaryField("author name", True, "name", str),
+                    SummaryField("author affiliation", False, "affiliation", str),
+                    SummaryField("author email", False, "email", str),
+                    SummaryField("author orcid", False, "orcid", str),
                 ],
-                False,
-                "Funding Bodies",
-                False,
+                mandatory=True,
+                title="Authors",
+                singular=False,
             ),
-            external=(
-                [
-                    ("external file", True, "file", str, []),
-                    ("external file description", True, "description", str, []),
+            funding=SummaryBlock(
+                fields=[
+                    SummaryField("funding body", True, "body", str),
+                    SummaryField("funding type", True, "type", str),
+                    SummaryField("funding reference", False, "ref", (str, int, float)),
+                    SummaryField("funding link", False, "url", str),
                 ],
-                False,
-                "External Files",
-                False,
+                mandatory=False,
+                title="Funding Bodies",
+                singular=False,
             ),
-            worksheet=(
-                [
-                    ("worksheet name", True, "name", str, []),
-                    ("worksheet title", True, "title", str, []),
-                    ("worksheet description", True, "description", str, []),
-                    ("worksheet external file", False, "external", str, []),
+            external=SummaryBlock(
+                fields=[
+                    SummaryField("external file", True, "file", str),
+                    SummaryField("external file description", True, "description", str),
                 ],
-                False,
-                "Worksheets",
-                False,
+                mandatory=False,
+                title="External Files",
+                singular=False,
             ),
-            permits=(
-                [
-                    ("permit type", True, "type", str, []),
-                    ("permit authority", True, "authority", str, []),
-                    ("permit number", True, "number", (str, int, float), []),
+            worksheet=SummaryBlock(
+                fields=[
+                    SummaryField("worksheet name", True, "name", str),
+                    SummaryField("worksheet title", True, "title", str),
+                    SummaryField("worksheet description", True, "description", str),
+                    SummaryField("worksheet external file", False, "external", str),
                 ],
-                False,
-                "Permits",
-                False,
+                mandatory=False,
+                title="Worksheets",
+                singular=False,
+            ),
+            permits=SummaryBlock(
+                fields=[
+                    SummaryField("permit type", True, "type", str),
+                    SummaryField("permit authority", True, "authority", str),
+                    SummaryField("permit number", True, "number", (str, int, float)),
+                ],
+                mandatory=False,
+                title="Permits",
+                singular=False,
             ),
         )
 
@@ -229,7 +271,6 @@ class Summary:
         worksheet: Worksheet,
         sheetnames: set,
         validate_doi: bool = False,
-        valid_pid: Union[None, int, list[int]] = None,
     ):
         """Populate a Summary instance from an Excel Worksheet.
 
@@ -237,34 +278,9 @@ class Summary:
             worksheet: An openpyxl worksheet instance.
             sheetnames: A set of sheet names found in the workbook.
             validate_doi: Should publication DOIs be validated (needs web connection).
-            valid_pid: If provided, an integer or list of integer values that are
-                permitted in the Project ID field (usually one for a new dataset but
-                more if a published dataset is associated with multiple projects and any
-                of those ids would be valid).
         """
         handler = get_handler()
         start_errors = handler.counters["ERROR"]
-
-        # validate project_id is one of None, an integer or a list of integers
-        if valid_pid is None:
-            pass
-        elif not self.use_project_ids:
-            LOGGER.error(
-                "Project IDs should not be provided, as your data manager does not use "
-                "them!"
-            )
-            self.valid_pid = None
-        elif isinstance(valid_pid, int):
-            self.valid_pid = [valid_pid]
-        elif isinstance(valid_pid, list):
-            if not all([isinstance(pid, int) for pid in valid_pid]):
-                LOGGER.error("Invalid value in list of project_ids.")
-                self.valid_pid = None
-            else:
-                self.valid_pid = valid_pid
-        else:
-            LOGGER.error("Provided project id must be an integer or list of integers")
-            self.valid_pid = None
 
         self.validate_doi = validate_doi
 
@@ -296,31 +312,9 @@ class Summary:
         # continue processing.
         self._rows = {str(rw[0]).lower(): rw[1:] for rw in rows}
 
-        # Check the minimal keys are expected - mandatory fields in mandatory blocks
-        found, aliases = self._check_for_mandatory_fields()
-
-        # Check only valid keys are found
-        valid_blocks = (blk[0] for blk in list(self.fields.values()))
-        valid_fields = {fld[0] for blk in valid_blocks for fld in blk}
-
-        # Add all aliases as valid fields
-        valid_fields.update(aliases)
-
-        if found - valid_fields:
-            LOGGER.error(
-                "Unknown metadata fields: ", extra={"join": found - valid_fields}
-            )
-
-        # TODO - the check below could probably be generalised for all aliases, but that
-        # doesn't seem a sensible use of time until we have more than one set
-
-        # Finally check that project ID field isn't included if project IDs are not used
-        if not self.use_project_ids:
-            if "project id" in found or "safe project id" in found:
-                LOGGER.error(
-                    "Project ID field should not be included, as your data manager "
-                    "does not use projects!"
-                )
+        # Validate the keys found in the summary table
+        found: set[str] = set(self._rows.keys())
+        self._validate_keys(found=found)
 
         # Now process the field blocks
         self._load_core(found)
@@ -342,59 +336,36 @@ class Summary:
         else:
             LOGGER.info("Summary formatted correctly")
 
-    def _check_for_mandatory_fields(self) -> tuple[set[str], set[str]]:
-        """Check that all mandatory fields are present.
+    def _validate_keys(self, found: set[str]) -> None:
+        """Validate the summary keys recovered.
 
-        This function also checks that if a field has an alias only one out of the alias
-        and the original name is provided.
-
-        Returns:
-            A tuple of sets, the first tuple element contains all the field headers
-            which were found, and the second tuple element contains all aliases.
+        This function checks that the keys in a summary table include the minimum set of
+        mandatory fields in mandatory blocks and that all found keys are known.
         """
 
-        # Find all required blocks
-        required_blocks = (blk[0] for blk in list(self.fields.values()) if blk[1])
+        # Find all required fields and known fields
+        required: set[str] = set()
+        known: set[str] = set()
 
-        required = set()
-        aliases = []
-
-        # Add all required headers to either required set or aliases set
-        for required_block in required_blocks:
-            for header in required_block:
-                # Required field with an alias
-                if header[1] and header[4]:
-                    alias_list = [header[0]] + header[4]
-                    aliases.append(set(alias_list))
-                elif header[1]:  # Required field without an alias
-                    required.add(header[0])
-
-        found = set(self._rows.keys())
-
-        if not found.issuperset(required):
-            LOGGER.error(
-                "Missing mandatory metadata fields: ", extra={"join": required - found}
-            )
-
-        # Check that one of each required alias is included
-        for alias_set in aliases:
-            present = found.intersection(alias_set)
-            if len(present) == 0:
-                LOGGER.error(
-                    "One of the following fields must be included: ",
-                    extra={"join": alias_set},
+        for block in self.fields.values():
+            # Required keys
+            if block.mandatory:
+                required = required.union(
+                    fld.key for fld in block.fields if fld.mandatory
                 )
-            elif len(present) > 1:
-                LOGGER.error(
-                    "Only one of the following fields should be included: ",
-                    extra={"join": alias_set},
-                )
+            # Known keys
+            known = known.union(fld.key for fld in block.fields)
 
-        return found, set().union(*aliases)
+        # Look for and report on issue
+        missing = required - found
+        unknown = found - known
+        if missing:
+            LOGGER.error("Missing mandatory metadata fields: ", extra={"join": missing})
 
-    def _read_block(
-        self, field_desc: tuple, mandatory: bool, title: str, only_one: bool
-    ) -> Optional[list]:
+        if unknown:
+            LOGGER.error("Unknown metadata fields: ", extra={"join": unknown})
+
+    def _read_block(self, block: SummaryBlock) -> Optional[list]:
         """Read a block of fields from a summary table.
 
         This internal method takes a given block definition from the Summary class
@@ -404,51 +375,51 @@ class Summary:
         specific functions to handle unique tests.
 
         Args:
-            field_desc: A list of tuples describing fields.
-            mandatory: Is the block mandatory?
-            title: The display title for the block
-            only_one: Are multiple records for the field an error?
+            block: A SummaryBlock instance describing the block
         """
 
-        mandatory_fields = [f[0] for f in field_desc if f[1]]
-        optional_fields = [f[0] for f in field_desc if not f[1]]
-        field_map = [(f[0], f[2]) for f in field_desc]
-        field_types = {f[0]: f[3] for f in field_desc}
+        mandatory_fields = [fld.key for fld in block.fields if fld.mandatory]
+        optional_fields = [fld.key for fld in block.fields if not fld.mandatory]
+        field_map = [
+            (fld.key, fld.internal) for fld in block.fields if fld.internal is not None
+        ]
+        field_types = {fld.key: fld.types for fld in block.fields}
 
-        # Get the full set of field names
+        # Get the full list of field names
         all_fields = mandatory_fields + optional_fields
 
         # Get the data, filling in completely missing rows
-        block = {
+        data = {
             k: self._rows[k] if k in self._rows else [None] * (self._ncols - 1)
             for k in all_fields
         }
 
         # Empty cells are already None, but also filter values to catch
         # pure whitespace content and replace with None
-        for ky, vals in block.items():
+        for ky, vals in data.items():
             vals = IsNotSpace(vals)
             if not vals:
                 LOGGER.error(f"Whitespace only cells in field {ky}")
 
-            block[ky] = vals.values
+            data[ky] = vals.values
 
         # Pivot to dictionary of records
-        block_list = [dict(zip(block.keys(), vals)) for vals in zip(*block.values())]
+        block_list = [dict(zip(data.keys(), vals)) for vals in zip(*data.values())]
 
         # Drop empty records
         block_list = [bl for bl in block_list if any(bl.values())]
 
+        # Contine if data are present
         if not block_list:
-            if mandatory:
-                LOGGER.error(f"No {title} metadata found")
+            if block.mandatory:
+                LOGGER.error(f"No {block.title} metadata found")
             else:
-                LOGGER.info(f"No {title} metadata found")
+                LOGGER.info(f"No {block.title} metadata found")
             return None
         else:
-            LOGGER.info(f"Metadata for {title} found: {len(block_list)} records")
+            LOGGER.info(f"Metadata for {block.title} found: {len(block_list)} records")
 
-            if len(block_list) > 1 and only_one:
+            if len(block_list) > 1 and block.singular:
                 LOGGER.error("Only a single record should be present")
 
             # report on block fields
@@ -473,8 +444,7 @@ class Summary:
                     )
 
             # remap names if provided
-            to_rename = (mp for mp in field_map if mp[1] is not None)
-            for old, new in to_rename:
+            for old, new in field_map:
                 for rec in block_list:
                     rec[new] = rec[old]
                     rec.pop(old)
@@ -483,7 +453,11 @@ class Summary:
 
     @loggerinfo_push_pop("Loading author metadata")
     def _load_authors(self):
-        authors = self._read_block(*self.fields["authors"])
+        """Load the author block.
+
+        Provides summary validation specific to the author block.
+        """
+        authors = self._read_block(self.fields["authors"])
 
         # Author specific validation
         if authors is not None:
@@ -525,7 +499,11 @@ class Summary:
 
     @loggerinfo_push_pop("Loading keywords metadata")
     def _load_keywords(self):
-        keywords = self._read_block(*self.fields["keywords"])
+        """Load the keywords block.
+
+        Provides summary validation specific to the keywords block.
+        """
+        keywords = self._read_block(self.fields["keywords"])
 
         # extra data validation for keywords
         if keywords:
@@ -541,10 +519,13 @@ class Summary:
 
     @loggerinfo_push_pop("Loading permit metadata")
     def _load_permits(self):
-        # LOOK FOR PERMIT DETAILS - users provide a permit authority, number and permit
-        # type
+        """Load the permits block.
 
-        permits = self._read_block(*self.fields["permits"])
+        Provides summary validation specific to the permits block - users provide a
+        permit authority, number and permit type.
+        """
+
+        permits = self._read_block(self.fields["permits"])
 
         # Permit specific checking for allowed permit types
         if permits:
@@ -562,8 +543,12 @@ class Summary:
 
     @loggerinfo_push_pop("Loading DOI metadata")
     def _load_doi(self):
+        """Load the DOI block.
+
+        Provides summary validation specific to the DOI block.
+        """
         # CHECK FOR PUBLICATION DOIs
-        pub_doi = self._read_block(*self.fields["doi"])
+        pub_doi = self._read_block(self.fields["doi"])
 
         # Extra data validation for DOIs
         if pub_doi is not None:
@@ -591,10 +576,16 @@ class Summary:
 
     @loggerinfo_push_pop("Loading funding metadata")
     def _load_funders(self):
+        """Load the funders block.
+
+        Provides summary validation specific to the permits block - users provide a
+        permit authority, number and permit type.
+        """
+
         # LOOK FOR FUNDING DETAILS - users provide a funding body and a description
         # of the funding type and then optionally a reference number and a URL
 
-        funders = self._read_block(*self.fields["funding"])
+        funders = self._read_block(self.fields["funding"])
 
         # TODO - currently no check beyond _read_block but maybe actually check
         #        the URL is a URL and maybe even opens? Could use urllib.parse
@@ -603,7 +594,11 @@ class Summary:
 
     @loggerinfo_push_pop("Loading temporal extent metadata")
     def _load_temporal_extent(self):
-        temp_extent = self._read_block(*self.fields["date"])
+        """Load the temporal extent block.
+
+        Provides summary validation specific to temporal extents.
+        """
+        temp_extent = self._read_block(self.fields["date"])
 
         # temporal extent validation and updating
         if temp_extent is not None:
@@ -632,8 +627,11 @@ class Summary:
 
     @loggerinfo_push_pop("Loading geographic extent metadata")
     def _load_geographic_extent(self):
-        # Geographic extents
-        geo_extent = self._read_block(*self.fields["geo"])
+        """Load the geographic extents block.
+
+        Provides summary validation specific to geographic extents block.
+        """
+        geo_extent = self._read_block(self.fields["geo"])
 
         if geo_extent is not None:
             bbox = geo_extent[0]
@@ -651,12 +649,15 @@ class Summary:
 
     @loggerinfo_push_pop("Loading external file metadata")
     def _load_external_files(self):
-        # LOAD EXTERNAL FILES - small datasets will usually be contained
-        # entirely in a single Excel file, but where formatting or size issues
-        # require external files, then names and descriptions are included in
-        # the summary information
+        """Load the external files block.
 
-        external_files = self._read_block(*self.fields["external"])
+        Provides summary validation specific to the external files block. Small datasets
+        will usually be contained entirely in a single Excel file, but where formatting
+        or size issues require external files, then names and descriptions are included
+        in the summary information.
+        """
+
+        external_files = self._read_block(self.fields["external"])
 
         # external file specific validation - no internal spaces.
         if external_files is not None:
@@ -676,8 +677,11 @@ class Summary:
 
     @loggerinfo_push_pop("Loading data worksheet metadata")
     def _load_data_worksheets(self, sheetnames):
-        # Load the WORKSHEETS block
-        data_worksheets = self._read_block(*self.fields["worksheet"])
+        """Load the worksheets block.
+
+        Provides summary validation specific to the worksheets block.
+        """
+        data_worksheets = self._read_block(self.fields["worksheet"])
 
         # Strip out faulty inclusion of Taxa and Location worksheets in
         # data worksheets before considering combinations of WS and external files
@@ -753,8 +757,12 @@ class Summary:
 
     @loggerinfo_push_pop("Loading access metadata")
     def _load_access_details(self):
-        # Load the ACCESS DETAILS block
-        access = self._read_block(*self.fields["access"])
+        """Load the access block.
+
+        Provides summary validation specific to the access block.
+        """
+
+        access = self._read_block(self.fields["access"])
         access = access[0]
 
         # Access specific validation - bad types handled by _read_block
@@ -807,34 +815,51 @@ class Summary:
 
     @loggerinfo_push_pop("Loading core metadata")
     def _load_core(self, found):
-        # Extract all core fields
-        core_fields = self.fields["core"]
+        """Load the core block.
 
-        # Make list of all core aliases
-        aliases = [core_field[4] for core_field in core_fields[0]]
-        # Then replace core field names with an alias where appropriate
-        for idx, alias_set in enumerate(aliases):
-            for alias in alias_set:
-                if alias in found:
-                    core_fields[0][idx] = (alias,) + core_fields[0][idx][1:4]
+        Provides summary validation specific to the core block.
+        """
 
-        core = self._read_block(*core_fields)
-        core = core[0]
-
+        core = self._read_block(self.fields["core"])
         self.title = core["title"]
         self.description = core["description"]
 
         # Project ID specific validation
-        pid = core["pid"]
+        # - Bail early if no validation should be done, warning if data provided.
+        if not self.projects:
+            if "project id" in core or "safe project id" in core:
+                LOGGER.error(
+                    "Projects are not configured but project ids are provided."
+                )
 
-        # Check the value is in the provided list
-        if pid is not None and self.valid_pid is not None and pid not in self.valid_pid:
+            return
+
+        # Now try and validate what is found.
+        if "project id" in core and "safe project id" in core:
             LOGGER.error(
-                f"Project ID in file ({pid}) does not match any provided project ids: ",
-                extra={"join": self.valid_pid},
+                "Use only project id not both project id and safe project id fields."
+            )
+            proj_ids = core["safe project id"] + core["project id"]
+        elif "project id" in core:
+            proj_ids = core["project id"]
+        elif "safe project id" in core:
+            LOGGER.warning(
+                "The 'project id' key is preferred over the "
+                "legacy 'safe project id' key."
+            )
+            proj_ids = core["safe project id"]
+        else:
+            LOGGER.error("Projects are configured and no project id field .")
+            return
+
+        # Check any provided values are valid
+        invalid_proj_ids = (p for p in proj_ids if p not in self.projects)
+        if invalid_proj_ids:
+            LOGGER.error(
+                "Invalid project ids provided: ", extra={"join": self.valid_pid}
             )
         else:
-            self.project_id = pid
+            self.project_ids = proj_ids
 
 
 def load_rows_from_worksheet(worksheet: Worksheet) -> list[tuple]:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -61,6 +61,9 @@ def fixture_files():
             appdirs.site_config_dir(), "safedata_validator", "safedata_validator.cfg"
         ),
         "fix_config": os.path.join(fixture_dir, "safedata_validator.cfg"),
+        "fix_config_no_projects": os.path.join(
+            fixture_dir, "safedata_validator_no_proj.cfg"
+        ),
     }
 
     return DotMap(
@@ -139,6 +142,10 @@ def config_filesystem(fs):
     config_contents[1] += FIXTURE_FILES.rf.localias_file
     config_contents[2] += FIXTURE_FILES.rf.gbif_file
     config_contents[3] += FIXTURE_FILES.rf.ncbi_file
+    fs.create_file(
+        FIXTURE_FILES.vf.fix_config_no_projects, contents="\n".join(config_contents)
+    )
+
     config_contents[4] += FIXTURE_FILES.rf.project_database_file
     fs.create_file(FIXTURE_FILES.vf.fix_config, contents="\n".join(config_contents))
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,6 @@
 """Collection of fixtures to assist the testing scripts."""
 import os
+import sys
 from collections import OrderedDict
 
 import appdirs
@@ -195,12 +196,35 @@ def log_check(caplog, expected_log):
 
     assert len(expected_log) == len(caplog.records)
 
-    assert all(
-        [exp[0] == rec.levelno for exp, rec in zip(expected_log, caplog.records)]
-    )
-    assert all(
-        [exp[1] in rec.message for exp, rec in zip(expected_log, caplog.records)]
-    )
+    level_correct = [
+        exp[0] == rec.levelno for exp, rec in zip(expected_log, caplog.records)
+    ]
+
+    message_correct = [
+        exp[1] in rec.message for exp, rec in zip(expected_log, caplog.records)
+    ]
+
+    if not all(level_correct):
+        failed_records = (
+            (exp, obs)
+            for passed, exp, obs in zip(level_correct, expected_log, caplog.records)
+            if not passed
+        )
+        for obs, exp in failed_records:
+            sys.stderr.write(f"Log level mismatch: {obs}, {exp.levelno, exp.message}")
+
+        assert False
+
+    if not all(message_correct):
+        failed_records = (
+            (exp, obs)
+            for passed, exp, obs in zip(message_correct, expected_log, caplog.records)
+            if not passed
+        )
+        for obs, exp in failed_records:
+            sys.stderr.write(f"Log message mismatch: {obs}, {exp.levelno, exp.message}")
+
+        assert False
 
 
 # ------------------------------------------

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -35,6 +35,8 @@ def fixture_files():
         ("gaz_file", "gazetteer_simple.geojson"),
         ("localias_file", "location_aliases_simple.csv"),
         ("empty_localias_file", "location_aliases_empty.csv"),
+        ("project_database_file", "project_database_simple.csv"),
+        ("project_database_file_bad", "project_database_bad.csv"),
         ("gbif_file", "gbif_backbone_truncated.sqlite"),
         ("ncbi_file", "ncbi_database_truncated.sqlite"),
         ("json_not_locations", "notalocationsjson.json"),
@@ -115,7 +117,7 @@ def config_filesystem(fs):
         "location_aliases = ",
         "gbif_database = ",
         "ncbi_database = ",
-        "use_project_ids = True",
+        "project_database = ",
         "[extents]",
         "temporal_soft_extent = 2002-02-02, 2030-01-31",
         "temporal_hard_extent = 2002-02-01, 2030-02-01",
@@ -137,6 +139,7 @@ def config_filesystem(fs):
     config_contents[1] += FIXTURE_FILES.rf.localias_file
     config_contents[2] += FIXTURE_FILES.rf.gbif_file
     config_contents[3] += FIXTURE_FILES.rf.ncbi_file
+    config_contents[4] += FIXTURE_FILES.rf.project_database_file
     fs.create_file(FIXTURE_FILES.vf.fix_config, contents="\n".join(config_contents))
 
     yield fs

--- a/test/fixtures/project_database_bad.csv
+++ b/test/fixtures/project_database_bad.csv
@@ -1,0 +1,3 @@
+project_id,title
+b,A test project
+c,Another test project

--- a/test/fixtures/project_database_simple.csv
+++ b/test/fixtures/project_database_simple.csv
@@ -1,0 +1,3 @@
+project_id,title
+1,A test project
+2,Another test project

--- a/test/test_resources.py
+++ b/test/test_resources.py
@@ -341,7 +341,7 @@ def nested_set(dic, keys, value):
                 (INFO, "Validating location aliases: "),
                 (INFO, "Validating GBIF database: "),
                 (INFO, "Validating NCBI database: "),
-                (INFO, "No project database configured"),
+                (INFO, "Configuration does not use project IDs."),
             ),
             id="Project_database provided",
         ),

--- a/test/test_summary.py
+++ b/test/test_summary.py
@@ -1442,113 +1442,63 @@ def test_load_rows_from_worksheet(data, expected_rows):
 
 
 @pytest.mark.parametrize(
-    argnames=["use_pids", "rows", "expected_log_entries"],
+    argnames=["rows", "expected_log_entries"],
     argvalues=[
         pytest.param(
-            True,
             {
-                "safe project id": [],
+                "title": [],
+                "description": [],
+                "access status": [],
+                "author name": [],
+                "keywords": [],
+            },
+            (),
+            id="good only mandatory",
+        ),
+        pytest.param(
+            {
+                "project id": [],
+                "title": [],
+                "description": [],
+                "access status": [],
+                "author name": [],
+                "keywords": [],
+            },
+            (),
+            id="good with optional",
+        ),
+        pytest.param(
+            {
                 "description": [],
                 "access status": [],
                 "author name": [],
                 "keywords": [],
             },
             ((ERROR, "Missing mandatory metadata fields:"),),
-            id="no title with pid",
+            id="missing title",
         ),
         pytest.param(
-            False,
             {
-                "description": [],
-                "access status": [],
-                "author name": [],
-                "keywords": [],
-            },
-            ((ERROR, "Missing mandatory metadata fields:"),),
-            id="no title without pid",
-        ),
-        pytest.param(
-            False,
-            {
+                "sproject id": [],
                 "title": [],
                 "description": [],
                 "access status": [],
                 "author name": [],
                 "keywords": [],
             },
-            (),
-            id="good without pid",
-        ),
-        pytest.param(
-            True,
-            {
-                "title": [],
-                "description": [],
-                "project id": [],
-                "access status": [],
-                "author name": [],
-                "keywords": [],
-            },
-            (),
-            id="good with pid",
-        ),
-        pytest.param(
-            True,
-            {
-                "title": [],
-                "description": [],
-                "safe project id": [],
-                "access status": [],
-                "author name": [],
-                "keywords": [],
-            },
-            (),
-            id="good legacy with pid",
-        ),
-        pytest.param(
-            True,
-            {
-                "title": [],
-                "description": [],
-                "project id": [],
-                "safe project id": [],
-                "access status": [],
-                "author name": [],
-                "keywords": [],
-            },
-            ((ERROR, "Only one of the following fields should be included:"),),
-            id="both aliases",
-        ),
-        pytest.param(
-            True,
-            {
-                "title": [],
-                "description": [],
-                "access status": [],
-                "author name": [],
-                "keywords": [],
-            },
-            ((ERROR, "One of the following fields must be included:"),),
-            id="no alias",
+            ((ERROR, "Unknown metadata fields:"),),
+            id="unknown field",
         ),
     ],
 )
-def test_check_for_mandatory_fields(
-    caplog, fixture_summary, use_pids, rows, expected_log_entries
-):
+def test_validate_keys(caplog, fixture_summary, rows, expected_log_entries):
     """Test that function to check mandatory fields works as expected."""
-
-    # Overwrite fixture default for checking
-    fixture_summary.use_project_ids = use_pids
-    pid_details = list(fixture_summary.fields["core"][0][0])
-    pid_details[1] = use_pids
-    fixture_summary.fields["core"][0][0] = tuple(pid_details)
 
     # Add rows to fixture
     fixture_summary._rows = rows
 
     # Check that row row headers contain mandatory fields
-    fixture_summary._check_for_mandatory_fields()
+    fixture_summary._validate_keys()
 
     log_check(caplog, expected_log_entries)
 

--- a/test/test_summary.py
+++ b/test/test_summary.py
@@ -1174,6 +1174,7 @@ def test_summary_load(fixture_summary, example_excel_files, n_errors):
                     "Both 'project id' and 'safe project id' provided: "
                     "use only 'project id'",
                 ),
+                (INFO, "Valid project ids provided:"),
             ),
             id="both project id keys provided",
         ),
@@ -1194,6 +1195,7 @@ def test_summary_load(fixture_summary, example_excel_files, n_errors):
                     WARNING,
                     "Use 'project id' rather than the legacy 'safe project id' key.",
                 ),
+                (INFO, "Valid project ids provided:"),
             ),
             id="using legacy safe project id",
         ),
@@ -1211,6 +1213,7 @@ def test_summary_load(fixture_summary, example_excel_files, n_errors):
                 (INFO, "Loading project id metadata"),
                 (INFO, "Metadata for Project IDs found:"),
                 (ERROR, "Unknown project ids provided"),
+                (INFO, "Valid project ids provided:"),
             ),
             id="unknown ids",
         ),
@@ -1227,6 +1230,7 @@ def test_summary_load(fixture_summary, example_excel_files, n_errors):
             (
                 (INFO, "Loading project id metadata"),
                 (INFO, "Metadata for Project IDs found:"),
+                (INFO, "Valid project ids provided:"),
             ),
             id="all good",
         ),


### PR DESCRIPTION
This PR:

* Removes the existing switches and logic for moving between `uses_project_ids`.
* Replaces them with an optional configuration resource: a CSV providing integer project codes and titles (at minimum)
* Updates `Resources`  to load that resource if configured
* `Summary` then validates project ids against the resource if provided and throws errors when invalid or unrequired project ids are provided.
* Added/updated testing for Project ID handling.

The PR also does some docs tidying (Summary attributes and broken sphinx style links  in `logger`). I've run this across the existing SAFE project datasets and it seems to work as intended!

Closes #89