### PR TITLE
Add args list to cli entry points to facilitate debugging

### DIFF
--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_build_local_gbif.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_build_local_gbif.txt
@@ -13,9 +13,9 @@ Build a local GBIF database.
     - to build a particular version, but defaults to the most recent version.
 
 positional arguments:
-  outdir                Location to create database file.
+  outdir        Location to create database file.
 
 optional arguments:
-  -h, --help            show this help message and exit
+  -h, --help    show this help message and exit
   -t TIMESTAMP, --timestamp TIMESTAMP
-                        The time stamp of a database archive version to use.
+                The time stamp of a database archive version to use.

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_build_local_ncbi.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_build_local_ncbi.txt
@@ -13,9 +13,9 @@ Build a local NCBI database.
     - to build a particular version, but defaults to the most recent version.
 
 positional arguments:
-  outdir                Location to create database file.
+  outdir        Location to create database file.
 
 optional arguments:
-  -h, --help            show this help message and exit
+  -h, --help    show this help message and exit
   -t TIMESTAMP, --timestamp TIMESTAMP
-                        The time stamp of a database archive version to use.
+                The time stamp of a database archive version to use.

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_metadata_show_resources.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_metadata_show_resources.txt
@@ -1,9 +1,9 @@
 cl_prompt $ safedata_metadata show_resources -h
 usage: safedata_metadata show_resources [-h]
 
-This subcommand simply shows the details of the resources being used and can be used
-to simply display the Zenodo and metadata server details of the default or specified
-resources file.
+This subcommand simply shows the details of the resources being used and can
+be used to simply display the Zenodo and metadata server details of the
+default or specified resources file.
 
 optional arguments:
   -h, --help  show this help message and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_metadata_top.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_metadata_top.txt
@@ -12,13 +12,15 @@ Post updated information to a safedata server instance.
 
 positional arguments:
   
-    post_metadata       Post dataset metadata to a safedata server
-    update_resources    Update the gazetteer data on safedata server
-    show_resources      Show the current resources details
+    post_metadata
+                Post dataset metadata to a safedata server
+    update_resources
+                Update the gazetteer data on safedata server
+    show_resources
+                Show the current resources details
 
 optional arguments:
-  -h, --help            show this help message and exit
+  -h, --help    show this help message and exit
   -r RESOURCES, --resources RESOURCES
-                        Path to a safedata_validator resource configuration
-                        file
-  -q, --quiet           Suppress normal information messages.
+                Path to a safedata_validator resource configuration file
+  -q, --quiet   Suppress normal information messages.

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_validate.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_validate.txt
@@ -23,18 +23,19 @@ Validate a dataset using a command line interface.
     The JSON metadata is used in the dataset publication process.
 
 positional arguments:
-  filename              Path to the Excel file to be validated.
+  filename      Path to the Excel file to be validated.
 
 optional arguments:
-  -h, --help            show this help message and exit
+  -h, --help    show this help message and exit
   -r RESOURCES, --resources RESOURCES
-                        A path to a resources configuration file
-  --validate_doi        Check the validity of any publication DOIs, provided
-                        by the user. Requires a web connection.
+                A path to a resources configuration file
+  --validate_doi
+                Check the validity of any publication DOIs, provided by the
+                user. Requires a web connection.
   --chunk_size CHUNK_SIZE
-                        Data are loaded from worksheets in chunks: the number
-                        of rows in a chunk is set by this argument
+                Data are loaded from worksheets in chunks: the number of rows
+                in a chunk is set by this argument
   -o OUTPUT, --output OUTPUT
-                        Save the validation report to a file, not print to the
-                        console.
-  --version             show program's version number and exit
+                Save the validation report to a file, not print to the
+                console.
+  --version     show program's version number and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_amend_metadata.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_amend_metadata.txt
@@ -1,6 +1,5 @@
 cl_prompt $ safedata_zenodo amend_metadata -h
-usage: safedata_zenodo [-h] [-r RESOURCES] [-q] SUBCOMMAND ... amend_metadata
-       [-h] zenodo_json_update
+usage: safedata_zenodo amend_metadata [-h] zenodo_json_update
 
 Updates the Zenodo metadata for an published deposit. To use this, make sure
 you have the most recent Zenodo metadata for the deposit and then edit the

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_create_deposit.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_create_deposit.txt
@@ -1,6 +1,5 @@
 cl_prompt $ safedata_zenodo create_deposit -h
-usage: safedata_zenodo [-h] [-r RESOURCES] [-q] SUBCOMMAND ... create_deposit
-       [-h] [-c CONCEPT_ID]
+usage: safedata_zenodo create_deposit [-h] [-c CONCEPT_ID]
 
 Create a new deposit draft. The concept_id option uses a provided Zenodo
 concept ID to creates a draft as a new version of an existing data set.

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_delete_file.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_delete_file.txt
@@ -1,12 +1,11 @@
 cl_prompt $ safedata_zenodo delete_file -h
-usage: safedata_zenodo [-h] [-r RESOURCES] [-q] SUBCOMMAND ... delete_file
-       [-h] zenodo_json filename
+usage: safedata_zenodo delete_file [-h] zenodo_json filename
 
 Delete an uploaded file from an unpublished deposit. The deposit metadata will
 be re-downloaded to ensure an up to date list of files in the deposit.
 
 positional arguments:
-  zenodo_json  Path to a Zenodo metadata file for the deposit to discard
+  zenodo_json  Path to a Zenodo JSON file for a deposit
   filename     The name of the file to delete
 
 optional arguments:

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_discard_deposit.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_discard_deposit.txt
@@ -1,12 +1,11 @@
 cl_prompt $ safedata_zenodo discard_deposit -h
-usage: safedata_zenodo [-h] [-r RESOURCES] [-q] SUBCOMMAND ... discard_deposit
-       [-h] zenodo_json
+usage: safedata_zenodo discard_deposit [-h] zenodo_json
 
 Discard an unpublished deposit. The deposit and all uploaded files will be
 removed from Zenodo.
 
 positional arguments:
-  zenodo_json  Path to a Zenodo metadata file for the deposit to discard
+  zenodo_json  Path to a Zenodo JSON file for a deposit
 
 optional arguments:
   -h, --help   show this help message and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_generate_html.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_generate_html.txt
@@ -1,6 +1,5 @@
 cl_prompt $ safedata_zenodo generate_html -h
-usage: safedata_zenodo [-h] [-r RESOURCES] [-q] SUBCOMMAND ... generate_html
-       [-h] zenodo_json dataset_json
+usage: safedata_zenodo generate_html [-h] zenodo_json dataset_json
 
 Generates an html file containing a standard description of a dataset from the
 JSON metadata. Usually this will be generated and uploaded as part of the
@@ -8,8 +7,8 @@ dataset publication process, but this subcommand can be used for local
 checking of the resulting HTML.
 
 positional arguments:
-  zenodo_json   Path to a Zenodo metadata file
-  dataset_json  Path to a dataset metadata file
+  zenodo_json   Path to a Zenodo JSON file for a deposit
+  dataset_json  Path to a JSON metadata file for a dataset
 
 optional arguments:
   -h, --help    show this help message and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_generate_xml.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_generate_xml.txt
@@ -1,14 +1,14 @@
 cl_prompt $ safedata_zenodo generate_xml -h
-usage: safedata_zenodo [-h] [-r RESOURCES] [-q] SUBCOMMAND ... generate_xml
-       [-h] [-l LINEAGE_STATEMENT] zenodo_json dataset_json
+usage: safedata_zenodo generate_xml [-h] [-l LINEAGE_STATEMENT]
+                                    zenodo_json dataset_json
 
 Creates an INSPIRE compliant XML metadata file for a published dataset,
 optionally including a user provided lineage statement (such as project
 details).
 
 positional arguments:
-  zenodo_json   Path to a Zenodo metadata file
-  dataset_json  Path to a dataset metadata file
+  zenodo_json   Path to a Zenodo JSON file for a deposit
+  dataset_json  Path to a JSON metadata file for a dataset
 
 optional arguments:
   -h, --help    show this help message and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_get_deposit.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_get_deposit.txt
@@ -1,6 +1,5 @@
 cl_prompt $ safedata_zenodo get_deposit -h
-usage: safedata_zenodo [-h] [-r RESOURCES] [-q] SUBCOMMAND ... get_deposit
-       [-h] zenodo_id
+usage: safedata_zenodo get_deposit [-h] zenodo_id
 
 Download the Zenodo metadata for a deposit and print out summary information.
 

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_maintain_ris.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_maintain_ris.txt
@@ -1,6 +1,5 @@
 cl_prompt $ safedata_zenodo maintain_ris -h
-usage: safedata_zenodo [-h] [-r RESOURCES] [-q] SUBCOMMAND ... maintain_ris
-       [-h] ris_file
+usage: safedata_zenodo maintain_ris [-h] ris_file
 
 This command maintains a RIS format bibliography file of the datasets
 uploaded to a Zenodo community. It can update an existing RIS format file

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_publish_deposit.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_publish_deposit.txt
@@ -1,6 +1,5 @@
 cl_prompt $ safedata_zenodo publish_deposit -h
-usage: safedata_zenodo [-h] [-r RESOURCES] [-q] SUBCOMMAND ... publish_deposit
-       [-h] zenodo_json
+usage: safedata_zenodo publish_deposit [-h] zenodo_json
 
 Publishes a Zenodo deposit. This is the final step in publishing a dataset and
 is not reversible. Once a dataset is published, the DOI associated with the
@@ -10,7 +9,7 @@ It may be worth reviewing the deposit webpage (https://zenodo.org/deposit/###)
 before finally publishing.
 
 positional arguments:
-  zenodo_json  Path to a Zenodo metadata file
+  zenodo_json  Path to a Zenodo JSON file for a deposit
 
 optional arguments:
   -h, --help   show this help message and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_show_resources.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_show_resources.txt
@@ -1,6 +1,5 @@
 cl_prompt $ safedata_zenodo show_resources -h
-usage: safedata_zenodo [-h] [-r RESOURCES] [-q] SUBCOMMAND ... show_resources
-       [-h]
+usage: safedata_zenodo show_resources [-h]
 
 Loads the safedata_validator resources file, displays the resources setup
 being used for safedata_zenodo and then exits.

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_sync_local_dir.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_sync_local_dir.txt
@@ -1,6 +1,7 @@
 cl_prompt $ safedata_zenodo sync_local_dir -h
-usage: safedata_zenodo [-h] [-r RESOURCES] [-q] SUBCOMMAND ... sync_local_dir
-       [-h] [--not-just-xlsx] [--replace-modified] datadir
+usage: safedata_zenodo sync_local_dir [-h] [--not-just-xlsx]
+                                      [--replace-modified]
+                                      datadir
 
 Synchronize a local data directory
 

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_top.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_top.txt
@@ -1,5 +1,5 @@
 cl_prompt $ safedata_zenodo -h
-usage: safedata_zenodo [-h] [-r RESOURCES] [-q] SUBCOMMAND ...
+usage: safedata_zenodo [-h] [-r RESOURCES] [-q]  ...
 
 Publish validated datasets to Zenodo using a command line interface.
 

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_upload_file.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_upload_file.txt
@@ -1,13 +1,13 @@
 cl_prompt $ safedata_zenodo upload_file -h
-usage: safedata_zenodo [-h] [-r RESOURCES] [-q] SUBCOMMAND ... upload_file
-       [-h] [--zenodo_filename ZENODO_FILENAME] zenodo_json filepath
+usage: safedata_zenodo upload_file [-h] [--zenodo_filename ZENODO_FILENAME]
+                                   zenodo_json filepath
 
 Uploads the contents of a specified file to an _unpublished_ Zenodo deposit,
 optionally using an alternative filename. If you upload a new file to the same
 filename, it will replace the existing uploaded file.
 
 positional arguments:
-  zenodo_json   Path to a Zenodo metadata JSON for the deposit
+  zenodo_json   Path to a Zenodo JSON file for a deposit
   filepath      The path to the file to be uploaded
 
 optional arguments:

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_upload_metadata.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_upload_metadata.txt
@@ -1,13 +1,12 @@
 cl_prompt $ safedata_zenodo upload_metadata -h
-usage: safedata_zenodo [-h] [-r RESOURCES] [-q] SUBCOMMAND ... upload_metadata
-       [-h] zenodo_json dataset_json
+usage: safedata_zenodo upload_metadata [-h] zenodo_json dataset_json
 
 Uses the dataset metadata created using `safedata_validate` to populate the
 required Zenodo metadata for an unpublished deposit.
 
 positional arguments:
-  zenodo_json   Path to a Zenodo metadata file
-  dataset_json  Path to a dataset metadata file
+  zenodo_json   Path to a Zenodo JSON file for a deposit
+  dataset_json  Path to a JSON metadata file for a dataset
 
 optional arguments:
   -h, --help    show this help message and exit

--- a/safedata_validator/entry_points.py
+++ b/safedata_validator/entry_points.py
@@ -788,6 +788,7 @@ def _safedata_zenodo_cli(args_list: Optional[list[str]] = None) -> None:
         )
 
         # Report on the outcome.
+        # FIXME: This is borked
         error = None
         if error is not None:
             LOGGER.error(f"Failed to generate INSPIRE xml: {error}")

--- a/safedata_validator/entry_points.py
+++ b/safedata_validator/entry_points.py
@@ -1,10 +1,12 @@
 """Provide command line scripts.
 
-This module provides command line scripts to expose validation and publishing
-functionality.
+This module provides functions exposed as command line entry points:
 
-* _safedata_validate_cli, exposed as `safedata_validate`
-* _safedata_zenodo_cli, exposed as `safedata_zenodo`
+* ``_safedata_validate_cli``, exposed as `safedata_validate`
+* ``_safedata_zenodo_cli``, exposed as `safedata_zenodo`
+* ``_safedata_metadata_cli``, exposed as `safedata_metadata`
+* ``_build_local_gbif_cli``, exposed as `safedata_build_local_gbif`
+* ``_build_local_ncbi_cli``, exposed as `safedata_build_local_ncbi`
 """
 
 import argparse
@@ -13,6 +15,7 @@ import sys
 import tempfile
 import textwrap
 from pathlib import Path
+from typing import Optional
 
 import simplejson
 
@@ -49,7 +52,12 @@ from safedata_validator.zenodo import (
 )
 
 
-def _safedata_validator_cli():
+def _desc_formatter(prog):
+    """Bespoke argparse description formatting."""
+    return argparse.RawDescriptionHelpFormatter(prog, max_help_position=16)
+
+
+def _safedata_validator_cli(args_list: Optional[list[str]] = None) -> None:
     """Validate a dataset using a command line interface.
 
     This program validates an Excel file formatted as a `safedata` dataset.
@@ -68,11 +76,33 @@ def _safedata_validator_cli():
     If validation is successful, then a JSON format file containing key
     metadata will be saved to the same location as the validated file.
     The JSON metadata is used in the dataset publication process.
+
+    Args:
+        args_list: This is a developer option used to simulate command line usage by
+            providing a list of command line argument strings to the entry point
+            function. For example, ``safedata_validate show_resources`` can be
+            replicated by calling ``_safedata_validate_cli(['show_resources'])``.
     """
 
-    desc = textwrap.dedent(_safedata_validator_cli.__doc__)
-    fmt = argparse.RawDescriptionHelpFormatter
-    parser = argparse.ArgumentParser(description=desc, formatter_class=fmt)
+    # If no arguments list is provided
+    if args_list is None:
+        args_list = sys.argv[1:]
+
+    # Check function docstring exists to safeguard against -OO mode, and strip off the
+    # description of the function args_list, which should not be included in the command
+    # line docs
+    if _safedata_validator_cli.__doc__ is not None:
+        desc = textwrap.dedent(
+            "\n".join(_safedata_validator_cli.__doc__.splitlines()[:-7])
+        )
+    else:
+        desc = "Python in -OO mode: no docs"
+
+    parser = argparse.ArgumentParser(
+        prog="safedata_validate",
+        description=desc,
+        formatter_class=_desc_formatter,
+    )
 
     parser.add_argument("filename", help="Path to the Excel file to be validated.")
 
@@ -115,7 +145,7 @@ def _safedata_validator_cli():
         version="%(prog)s {version}".format(version=__version__),
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(args=args_list)
 
     # Configure the logging location
     if args.output is None:
@@ -143,12 +173,7 @@ def _safedata_validator_cli():
         sys.stdout.write("------------------------\n")
 
 
-def _desc_formatter(prog):
-    """Bespoke argparse description formatting."""
-    return argparse.RawDescriptionHelpFormatter(prog, max_help_position=16)
-
-
-def _safedata_zenodo_cli():
+def _safedata_zenodo_cli(args_list: Optional[list[str]] = None) -> None:
     """Publish validated datasets to Zenodo using a command line interface.
 
     This is a the command line interface for publishing safedata validated
@@ -176,16 +201,33 @@ def _safedata_zenodo_cli():
         associated with a Zenodo deposit or published record.
 
     Note that most of these actions are also available via the Zenodo website.
+
+    Args:
+        args_list: This is a developer option used to simulate command line usage by
+            providing a list of command line argument strings to the entry point
+            function. For example, ``safedata_zenodo create_deposit`` can be
+            replicated by calling ``_safedata_zenodo_cli(['create_deposit'])``.
     """
 
+    # If no arguments list is provided
+    if args_list is None:
+        args_list = sys.argv[1:]
+
+    # Check function docstring exists to safeguard against -OO mode, and strip off the
+    # description of the function args_list, which should not be included in the command
+    # line docs
+    if _safedata_zenodo_cli.__doc__ is not None:
+        desc = textwrap.dedent(
+            "\n".join(_safedata_zenodo_cli.__doc__.splitlines()[:-7])
+        )
+    else:
+        desc = "Python in -OO mode: no docs"
+
     # create the top-level parser and configure to take subparsers
-    desc = textwrap.dedent(_safedata_zenodo_cli.__doc__)
-    fmt = _desc_formatter
     parser = argparse.ArgumentParser(
         prog="safedata_zenodo",
         description=desc,
-        formatter_class=fmt,
-        usage="safedata_zenodo [-h] [-r RESOURCES] [-q] SUBCOMMAND ...",
+        formatter_class=_desc_formatter,
     )
 
     parser.add_argument(
@@ -203,6 +245,24 @@ def _safedata_zenodo_cli():
         help="Suppress normal information messages. ",
     )
 
+    # Create subparsers to add shared options across actions - these can be added to
+    # individual actions via the parents argument
+    parse_zenodo_metadata = argparse.ArgumentParser(add_help=False)
+    parse_zenodo_metadata.add_argument(
+        "zenodo_json",
+        type=str,
+        default=None,
+        help="Path to a Zenodo JSON file for a deposit",
+    )
+
+    parse_dataset_metadata = argparse.ArgumentParser(add_help=False)
+    parse_dataset_metadata.add_argument(
+        "dataset_json",
+        type=str,
+        default=None,
+        help="Path to a JSON metadata file for a dataset",
+    )
+
     subparsers = parser.add_subparsers(dest="subcommand", metavar="")
 
     # CREATE DEPOSIT subcommand
@@ -218,7 +278,7 @@ def _safedata_zenodo_cli():
         "create_deposit",
         description=textwrap.dedent(create_deposit_desc),
         help="Create a new Zenodo draft deposit",
-        formatter_class=fmt,
+        formatter_class=_desc_formatter,
     )
 
     create_deposit_parser.add_argument(
@@ -235,18 +295,12 @@ def _safedata_zenodo_cli():
     removed from Zenodo.
     """
 
-    discard_deposit_parser = subparsers.add_parser(
+    discard_deposit_parser = subparsers.add_parser(  # noqa: F841
         "discard_deposit",
         description=textwrap.dedent(discard_deposit_desc),
         help="Discard an unpublished deposit",
-        formatter_class=fmt,
-    )
-
-    discard_deposit_parser.add_argument(
-        "zenodo_json",
-        type=str,
-        default=None,
-        help="Path to a Zenodo metadata file for the deposit to discard",
+        formatter_class=_desc_formatter,
+        parents=[parse_zenodo_metadata],
     )
 
     # GET DEPOSIT subcommand
@@ -276,15 +330,12 @@ def _safedata_zenodo_cli():
     before finally publishing.
     """
 
-    publish_deposit_parser = subparsers.add_parser(
+    publish_deposit_parser = subparsers.add_parser(  # noqa: F841
         "publish_deposit",
         description=textwrap.dedent(publish_deposit_desc),
         help="Publish a draft deposit",
-        formatter_class=fmt,
-    )
-
-    publish_deposit_parser.add_argument(
-        "zenodo_json", type=str, help="Path to a Zenodo metadata file"
+        formatter_class=_desc_formatter,
+        parents=[parse_zenodo_metadata],
     )
 
     # UPLOAD FILE subcommand
@@ -298,15 +349,10 @@ def _safedata_zenodo_cli():
         "upload_file",
         description=textwrap.dedent(upload_file_desc),
         help="Upload a file to an unpublished deposit",
-        formatter_class=fmt,
+        formatter_class=_desc_formatter,
+        parents=[parse_zenodo_metadata],
     )
 
-    upload_file_parser.add_argument(
-        "zenodo_json",
-        type=str,
-        default=None,
-        help="Path to a Zenodo metadata JSON for the deposit",
-    )
     upload_file_parser.add_argument(
         "filepath", type=str, default=None, help="The path to the file to be uploaded"
     )
@@ -327,15 +373,10 @@ def _safedata_zenodo_cli():
         "delete_file",
         description=textwrap.dedent(delete_file_desc),
         help="Delete a file from an unpublished deposit",
-        formatter_class=fmt,
+        formatter_class=_desc_formatter,
+        parents=[parse_zenodo_metadata],
     )
 
-    delete_file_parser.add_argument(
-        "zenodo_json",
-        type=str,
-        default=None,
-        help="Path to a Zenodo metadata file for the deposit to discard",
-    )
     delete_file_parser.add_argument(
         "filename", type=str, default=None, help="The name of the file to delete"
     )
@@ -346,18 +387,12 @@ def _safedata_zenodo_cli():
     required Zenodo metadata for an unpublished deposit.
     """
 
-    upload_metadata_parser = subparsers.add_parser(
+    upload_metadata_parser = subparsers.add_parser(  # noqa: F841
         "upload_metadata",
         description=textwrap.dedent(upload_metadata_desc),
         help="Populate the Zenodo metadata",
-        formatter_class=fmt,
-    )
-
-    upload_metadata_parser.add_argument(
-        "zenodo_json", type=str, help="Path to a Zenodo metadata file"
-    )
-    upload_metadata_parser.add_argument(
-        "dataset_json", type=str, help="Path to a dataset metadata file"
+        formatter_class=_desc_formatter,
+        parents=[parse_zenodo_metadata, parse_dataset_metadata],
     )
 
     # AMEND METADATA subcommand
@@ -375,7 +410,7 @@ def _safedata_zenodo_cli():
         "amend_metadata",
         description=textwrap.dedent(amend_metadata_desc),
         help="Update published Zenodo metadata",
-        formatter_class=fmt,
+        formatter_class=_desc_formatter,
     )
 
     amend_metadata_parser.add_argument(
@@ -407,7 +442,7 @@ def _safedata_zenodo_cli():
         "sync_local_dir",
         description=textwrap.dedent(sync_local_dir_desc),
         help="Create or update a local safedata directory",
-        formatter_class=fmt,
+        formatter_class=_desc_formatter,
     )
 
     sync_local_dir_parser.add_argument(
@@ -445,7 +480,7 @@ def _safedata_zenodo_cli():
         "maintain_ris",
         description=textwrap.dedent(maintain_ris_desc),
         help="Maintain a RIS bibliography file for datasets",
-        formatter_class=fmt,
+        formatter_class=_desc_formatter,
     )
 
     # positional argument inputs
@@ -465,17 +500,11 @@ def _safedata_zenodo_cli():
     resulting HTML.
     """
 
-    generate_html_parser = subparsers.add_parser(
+    generate_html_parser = subparsers.add_parser(  # noqa: F841
         "generate_html",
         description=textwrap.dedent(generate_html_desc),
         help="Generate an HTML dataset description",
-    )
-
-    generate_html_parser.add_argument(
-        "zenodo_json", type=str, help="Path to a Zenodo metadata file"
-    )
-    generate_html_parser.add_argument(
-        "dataset_json", type=str, help="Path to a dataset metadata file"
+        parents=[parse_zenodo_metadata, parse_dataset_metadata],
     )
 
     # GENERATE XML subcommand
@@ -489,15 +518,10 @@ def _safedata_zenodo_cli():
         "generate_xml",
         description=textwrap.dedent(generate_xml_desc),
         help="Create INSPIRE compliant metadata XML",
-        formatter_class=fmt,
+        formatter_class=_desc_formatter,
+        parents=[parse_zenodo_metadata, parse_dataset_metadata],
     )
 
-    generate_xml_parser.add_argument(
-        "zenodo_json", type=str, help="Path to a Zenodo metadata file"
-    )
-    generate_xml_parser.add_argument(
-        "dataset_json", type=str, help="Path to a dataset metadata file"
-    )
     generate_xml_parser.add_argument(
         "-l",
         "--lineage-statement",
@@ -516,7 +540,7 @@ def _safedata_zenodo_cli():
         "show_resources",
         description=textwrap.dedent(show_resources_desc),
         help="Report the config being used and exit",
-        formatter_class=fmt,
+        formatter_class=_desc_formatter,
     )
 
     # ------------------------------------------------------
@@ -524,7 +548,7 @@ def _safedata_zenodo_cli():
     # ------------------------------------------------------
 
     # Parse the arguments and set the verbosity
-    args = parser.parse_args()
+    args = parser.parse_args(args=args_list)
 
     if args.subcommand is None:
         parser.print_usage()
@@ -707,7 +731,7 @@ def _safedata_zenodo_cli():
 
         # Run the function
         response, error = update_published_metadata(
-            zenodo_md=zenodo_json_update,
+            zenodo=zenodo_json_update,
             resources=resources,
         )
 
@@ -733,8 +757,10 @@ def _safedata_zenodo_cli():
         # Run the download RIS data function
         with open(args.dataset_json) as ds_json:
             dataset_json = simplejson.load(ds_json)
+        with open(args.zenodo_json) as zn_json:
+            zenodo_json = simplejson.load(zn_json)
 
-        desc = dataset_description(metadata=dataset_json)
+        desc = dataset_description(metadata=dataset_json, zenodo=zenodo_json)
 
         with open(args.html_out, "w") as outf:
             outf.write(desc)
@@ -749,19 +775,20 @@ def _safedata_zenodo_cli():
 
         if args.lineage_statement is not None:
             with open(args.lineage_statement) as lin_file:
-                lineage_statement = lin_file.readlines()
+                lineage_statement = lin_file.read()
         else:
             lineage_statement = None
 
         # Run the function
-        response, error = generate_inspire_xml(
+        generated_xml = generate_inspire_xml(  # noqa: F841
             metadata=dataset_json,
-            zenodo=zenodo_json,
+            zenodo_metadata=zenodo_json,
             resources=resources,
             lineage_statement=lineage_statement,
         )
 
         # Report on the outcome.
+        error = None
         if error is not None:
             LOGGER.error(f"Failed to generate INSPIRE xml: {error}")
         else:
@@ -770,7 +797,7 @@ def _safedata_zenodo_cli():
     return
 
 
-def _safedata_metadata_cli():
+def _safedata_metadata_cli(args_list: Optional[list[str]] = None) -> None:
     """Post updated information to a safedata server instance.
 
     This command line tool provides functions to update a web server running
@@ -779,12 +806,34 @@ def _safedata_metadata_cli():
 
     To use these tools, the safedata_validator Resources configuration must
     contain the URL for the server and an access token.
+
+    Args:
+        args_list: This is a developer option used to simulate command line usage by
+            providing a list of command line argument strings to the entry point
+            function. For example, ``safedata_zenodo create_deposit`` can be
+            replicated by calling ``_safedata_zenodo_cli(['create_deposit'])``.
     """
 
+    # If no arguments list is provided
+    if args_list is None:
+        args_list = sys.argv[1:]
+
+    # Check function docstring exists to safeguard against -OO mode, and strip off the
+    # description of the function args_list, which should not be included in the command
+    # line docs
+    if _safedata_metadata_cli.__doc__ is not None:
+        desc = textwrap.dedent(
+            "\n".join(_safedata_metadata_cli.__doc__.splitlines()[:-7])
+        )
+    else:
+        desc = "Python in -OO mode: no docs"
+
     # create the top-level parser and configure to take subparsers
-    desc = textwrap.dedent(_safedata_metadata_cli.__doc__)
-    fmt = argparse.RawDescriptionHelpFormatter
-    parser = argparse.ArgumentParser(description=desc, formatter_class=fmt)
+    parser = argparse.ArgumentParser(
+        prog="safedata_metadata",
+        description=desc,
+        formatter_class=_desc_formatter,
+    )
 
     parser.add_argument(
         "-r",
@@ -816,7 +865,7 @@ def _safedata_metadata_cli():
         "post_metadata",
         description=textwrap.dedent(post_metadata_desc),
         help="Post dataset metadata to a safedata server",
-        formatter_class=fmt,
+        formatter_class=_desc_formatter,
     )
 
     # positional argument inputs
@@ -842,7 +891,7 @@ def _safedata_metadata_cli():
         "update_resources",
         description=textwrap.dedent(update_resources_desc),
         help="Update the gazetteer data on safedata server",
-        formatter_class=fmt,
+        formatter_class=_desc_formatter,
     )
 
     # SHOW RESOURCES subcommand, which has no arguments
@@ -857,7 +906,7 @@ def _safedata_metadata_cli():
         "show_resources",
         description=textwrap.dedent(show_resources_desc),
         help="Show the current resources details",
-        formatter_class=fmt,
+        formatter_class=_desc_formatter,
     )
 
     # ------------------------------------------------------
@@ -865,7 +914,7 @@ def _safedata_metadata_cli():
     # ------------------------------------------------------
 
     # Parse the arguments and set the verbosity
-    args = parser.parse_args()
+    args = parser.parse_args(args=args_list)
 
     if args.subcommand is None:
         parser.print_usage()
@@ -929,7 +978,7 @@ def _safedata_metadata_cli():
 # Local Database building
 
 
-def _build_local_gbif_cli():
+def _build_local_gbif_cli(args_list: Optional[list[str]] = None) -> None:
     """Build a local GBIF database.
 
     This tool builds an SQLite database of the GBIF backbone taxonomy to use
@@ -940,11 +989,34 @@ def _build_local_gbif_cli():
 
     The tool will optionally take a timestamp - using the format '2021-11-26'
     - to build a particular version, but defaults to the most recent version.
+
+    Args:
+        args_list: This is a developer option used to simulate command line usage by
+            providing a list of command line argument strings to the entry point
+            function. For example, ``safedata_zenodo create_deposit`` can be
+            replicated by calling ``_safedata_zenodo_cli(['create_deposit'])``.
     """
 
-    desc = textwrap.dedent(_build_local_gbif_cli.__doc__)
-    fmt = argparse.RawDescriptionHelpFormatter
-    parser = argparse.ArgumentParser(description=desc, formatter_class=fmt)
+    # If no arguments list is provided
+    if args_list is None:
+        args_list = sys.argv[1:]
+
+    # Check function docstring exists to safeguard against -OO mode, and strip off the
+    # description of the function args_list, which should not be included in the command
+    # line docs
+    if _build_local_gbif_cli.__doc__ is not None:
+        desc = textwrap.dedent(
+            "\n".join(_build_local_gbif_cli.__doc__.splitlines()[:-7])
+        )
+    else:
+        desc = "Python in -OO mode: no docs"
+
+    # create the parser
+    parser = argparse.ArgumentParser(
+        prog="safedata_build_local_gbif",
+        description=desc,
+        formatter_class=_desc_formatter,
+    )
 
     parser.add_argument("outdir", help="Location to create database file.")
     parser.add_argument(
@@ -955,7 +1027,7 @@ def _build_local_gbif_cli():
         help="The time stamp of a database archive version to use.",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(args=args_list)
 
     with tempfile.TemporaryDirectory() as download_loc:
         file_data = download_gbif_backbone(
@@ -966,7 +1038,7 @@ def _build_local_gbif_cli():
     return
 
 
-def _build_local_ncbi_cli():
+def _build_local_ncbi_cli(args_list: Optional[list[str]] = None) -> None:
     """Build a local NCBI database.
 
     This tool builds an SQLite database of the NCBI  taxonomy to use in
@@ -977,11 +1049,34 @@ def _build_local_ncbi_cli():
 
     The tool will optionally take a timestamp - using the format '2021-11-26'
     - to build a particular version, but defaults to the most recent version.
+
+    Args:
+        args_list: This is a developer option used to simulate command line usage by
+            providing a list of command line argument strings to the entry point
+            function. For example, ``safedata_zenodo create_deposit`` can be
+            replicated by calling ``_safedata_zenodo_cli(['create_deposit'])``.
     """
 
-    desc = textwrap.dedent(_build_local_ncbi_cli.__doc__)
-    fmt = argparse.RawDescriptionHelpFormatter
-    parser = argparse.ArgumentParser(description=desc, formatter_class=fmt)
+    # If no arguments list is provided
+    if args_list is None:
+        args_list = sys.argv[1:]
+
+    # Check function docstring exists to safeguard against -OO mode, and strip off the
+    # description of the function args_list, which should not be included in the command
+    # line docs
+    if _build_local_ncbi_cli.__doc__ is not None:
+        desc = textwrap.dedent(
+            "\n".join(_build_local_ncbi_cli.__doc__.splitlines()[:-7])
+        )
+    else:
+        desc = "Python in -OO mode: no docs"
+
+    # create the parser
+    parser = argparse.ArgumentParser(
+        prog="safedata_build_local_ncbi",
+        description=desc,
+        formatter_class=_desc_formatter,
+    )
 
     parser.add_argument("outdir", help="Location to create database file.")
     parser.add_argument(
@@ -992,7 +1087,7 @@ def _build_local_ncbi_cli():
         help="The time stamp of a database archive version to use.",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(args=args_list)
 
     with tempfile.TemporaryDirectory() as download_loc:
         file_data = download_ncbi_taxonomy(

--- a/test/test_entry_points.py
+++ b/test/test_entry_points.py
@@ -1,15 +1,9 @@
 """Test that Extent logs correctly."""
 
-import importlib
 import subprocess
 from contextlib import contextmanager
-from logging import CRITICAL, ERROR, WARNING
 
 import pytest
-
-from safedata_validator.extent import Extent
-
-from .conftest import log_check
 
 
 @contextmanager
@@ -30,12 +24,12 @@ def does_not_raise():
 def test_entry_points_run(entry_point):
     """This test checks the availability and basic function of the package entry points.
 
-    The tests do not test complex function, just that the entry point is available and
-    exits normally after getting the help text. For some reason, these tests fail in
-    VSCode debug mode, something to do with multiprocessing and shell=True?
+    The tests do not test complex functionality, just that the entry point is available
+    and exits normally after getting the help text. For some reason, these tests fail in
+    VSCode debug mode.
     """
 
-    result = subprocess.run([entry_point, "-h"])
+    result = subprocess.run(f"{entry_point} -h", shell=True)
 
     assert result.returncode == 0
 

--- a/test/test_entry_points.py
+++ b/test/test_entry_points.py
@@ -1,0 +1,68 @@
+"""Test that Extent logs correctly."""
+
+import importlib
+import subprocess
+from contextlib import contextmanager
+from logging import CRITICAL, ERROR, WARNING
+
+import pytest
+
+from safedata_validator.extent import Extent
+
+from .conftest import log_check
+
+
+@contextmanager
+def does_not_raise():
+    yield
+
+
+@pytest.mark.parametrize(
+    argnames="entry_point",
+    argvalues=[
+        "safedata_validate",
+        "safedata_zenodo",
+        "safedata_metadata",
+        "safedata_build_local_gbif",
+        "safedata_build_local_ncbi",
+    ],
+)
+def test_entry_points_run(entry_point):
+    """This test checks the availability and basic function of the package entry points.
+
+    The tests do not test complex function, just that the entry point is available and
+    exits normally after getting the help text. For some reason, these tests fail in
+    VSCode debug mode, something to do with multiprocessing and shell=True?
+    """
+
+    result = subprocess.run([entry_point, "-h"])
+
+    assert result.returncode == 0
+
+
+@pytest.mark.parametrize(
+    argnames="entry_point",
+    argvalues=[
+        "_safedata_validator_cli",
+        "_safedata_zenodo_cli",
+        "_safedata_metadata_cli",
+        "_build_local_gbif_cli",
+        "_build_local_ncbi_cli",
+    ],
+)
+def test_entry_points_via_call(entry_point):
+    """This test checks that the entry points can all be invoked directly.
+
+    The tests do not test complex function, just that the underlying entry point
+    function can be called with a list of arguments. The test asks the function to print
+    the function help, which results in a SystemExit that needs to be handled.
+    """
+
+    from safedata_validator import entry_points
+
+    entry_point_function = getattr(entry_points, entry_point)
+
+    with pytest.raises(SystemExit) as exit:
+        entry_point_function(args_list=["-h"])
+
+    assert exit.value.code == 0


### PR DESCRIPTION
This PR closes #107 by:

* Adding the args_list argument to all of the entry point functions and handling that within the function
* Adds simple testing that the entry points CLI and entry points functions can be invoked with '-h' successfully.
* Does some tidying up of shared parser arguments and formatting
* Regenerates the command line usage for the docs.

For further work:
- Extend the basic entry point testing to include local actions (where there is no need to mock remote stuff) #110 
- Fix the broken XML generation. #109 