### PR TITLE
Fixing OS specific issues with logging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,7 +26,7 @@
             ]
         },
         {
-            "name": "_safedata_validator_cli debug",
+            "name": "_safedata_validate_cli debug",
             "type": "python",
             "request": "launch",
             "program": "${file}",

--- a/devtools/debugging_an_entry_point.py
+++ b/devtools/debugging_an_entry_point.py
@@ -14,7 +14,7 @@ safedata_validate \
 ```
 
 The `safedata_validate` command line function is a pointer to the
-`safedata_validator.entry_points._safedata_validator_cli` function, which then handles
+`safedata_validator.entry_points._safedata_validate_cli` function, which then handles
 parsing those command line arguments using `argparse`. In order to allow this to be
 debugged, the _Python_ function needs to be run from within a Python debugger, and hence
 needs a way to provide those arguments to `argparse`.
@@ -25,7 +25,7 @@ The JSON to do that looks like this:
 
 ```json
     {
-        "name": "_safedata_validator_cli debug",
+        "name": "_safedata_validate_cli debug",
         "type": "python",
         "request": "launch",
         "program": "${file}",
@@ -49,6 +49,6 @@ arguments given in the 'args' data above. Breakpoints in the code can then be us
 interact with the running code and allow step through.
 """
 
-from safedata_validator.entry_points import _safedata_validator_cli
+from safedata_validator.entry_points import _safedata_validate_cli
 
-_safedata_validator_cli()
+_safedata_validate_cli()

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_validate.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_validate.txt
@@ -1,6 +1,7 @@
 cl_prompt $ safedata_validate -h
 usage: safedata_validate [-h] [-r RESOURCES] [--validate_doi]
-                         [--chunk_size CHUNK_SIZE] [-o OUTPUT] [--version]
+                         [--chunk_size CHUNK_SIZE] [-l LOG] [-j JSON]
+                         [--version]
                          filename
 
 Validate a dataset using a command line interface.
@@ -19,8 +20,14 @@ Validate a dataset using a command line interface.
     your operating system.
 
     If validation is successful, then a JSON format file containing key
-    metadata will be saved to the same location as the validated file.
-    The JSON metadata is used in the dataset publication process.
+    metadata will be saved. This is used in the dataset publication process.
+    By default, the JSON file is saved to the same directory as the input
+    file, using the same filename but with the `.json` extension. This can
+    be saved elsewhere using the `--json` option.
+
+    The command also outputs a log of the validation process, which
+    identifies validation issues. This defaults to being written to
+    stderr but can be redirected to a file using the `--log` option.
 
 positional arguments:
   filename      Path to the Excel file to be validated.
@@ -35,7 +42,8 @@ optional arguments:
   --chunk_size CHUNK_SIZE
                 Data are loaded from worksheets in chunks: the number of rows
                 in a chunk is set by this argument
-  -o OUTPUT, --output OUTPUT
-                Save the validation report to a file, not print to the
-                console.
+  -l LOG, --log LOG
+                Save the validation log to a file, not print to the console.
+  -j JSON, --json JSON
+                An optional output path for the validated dataset JSON.
   --version     show program's version number and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_generate_html.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_generate_html.txt
@@ -1,5 +1,5 @@
 cl_prompt $ safedata_zenodo generate_html -h
-usage: safedata_zenodo generate_html [-h] zenodo_json dataset_json
+usage: safedata_zenodo generate_html [-h] zenodo_json dataset_json html_out
 
 Generates an html file containing a standard description of a dataset from the
 JSON metadata. Usually this will be generated and uploaded as part of the
@@ -9,6 +9,7 @@ checking of the resulting HTML.
 positional arguments:
   zenodo_json   Path to a Zenodo JSON file for a deposit
   dataset_json  Path to a JSON metadata file for a dataset
+  html_out      Output path for the HTML file
 
 optional arguments:
   -h, --help    show this help message and exit

--- a/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_generate_xml.txt
+++ b/docs/data_managers/command_line_tools/command_line_usage/safedata_zenodo_generate_xml.txt
@@ -1,6 +1,6 @@
 cl_prompt $ safedata_zenodo generate_xml -h
 usage: safedata_zenodo generate_xml [-h] [-l LINEAGE_STATEMENT]
-                                    zenodo_json dataset_json
+                                    zenodo_json dataset_json xml_out
 
 Creates an INSPIRE compliant XML metadata file for a published dataset,
 optionally including a user provided lineage statement (such as project
@@ -9,6 +9,7 @@ details).
 positional arguments:
   zenodo_json   Path to a Zenodo JSON file for a deposit
   dataset_json  Path to a JSON metadata file for a dataset
+  xml_out       Output path for the XML file
 
 optional arguments:
   -h, --help    show this help message and exit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 license = "MIT"
 
 [tool.poetry.scripts]
-safedata_validate = "safedata_validator.entry_points:_safedata_validator_cli"
+safedata_validate = "safedata_validator.entry_points:_safedata_validate_cli"
 safedata_zenodo = "safedata_validator.entry_points:_safedata_zenodo_cli"
 safedata_metadata = "safedata_validator.entry_points:_safedata_metadata_cli"
 safedata_build_local_gbif = "safedata_validator.entry_points:_build_local_gbif_cli"

--- a/safedata_validator/entry_points.py
+++ b/safedata_validator/entry_points.py
@@ -57,7 +57,7 @@ def _desc_formatter(prog):
     return argparse.RawDescriptionHelpFormatter(prog, max_help_position=16)
 
 
-def _safedata_validator_cli(args_list: Optional[list[str]] = None) -> int:
+def _safedata_validate_cli(args_list: Optional[list[str]] = None) -> int:
     """Validate a dataset using a command line interface.
 
     This program validates an Excel file formatted as a `safedata` dataset.
@@ -74,8 +74,14 @@ def _safedata_validator_cli(args_list: Optional[list[str]] = None) -> int:
     your operating system.
 
     If validation is successful, then a JSON format file containing key
-    metadata will be saved to the same location as the validated file.
-    The JSON metadata is used in the dataset publication process.
+    metadata will be saved. This is used in the dataset publication process.
+    By default, the JSON file is saved to the same directory as the input
+    file, using the same filename but with the `.json` extension. This can
+    be saved elsewhere using the `--json` option.
+
+    The command also outputs a log of the validation process, which
+    identifies validation issues. This defaults to being written to
+    stderr but can be redirected to a file using the `--log` option.
 
     Args:
         args_list: This is a developer option used to simulate command line usage by
@@ -94,9 +100,9 @@ def _safedata_validator_cli(args_list: Optional[list[str]] = None) -> int:
     # Check function docstring exists to safeguard against -OO mode, and strip off the
     # description of the function args_list, which should not be included in the command
     # line docs
-    if _safedata_validator_cli.__doc__ is not None:
+    if _safedata_validate_cli.__doc__ is not None:
         desc = textwrap.dedent(
-            "\n".join(_safedata_validator_cli.__doc__.splitlines()[:-10])
+            "\n".join(_safedata_validate_cli.__doc__.splitlines()[:-10])
         )
     else:
         desc = "Python in -OO mode: no docs"
@@ -135,11 +141,19 @@ def _safedata_validator_cli(args_list: Optional[list[str]] = None) -> int:
         ),
     )
     parser.add_argument(
-        "-o",
-        "--output",
+        "-l",
+        "--log",
         default=None,
         type=Path,
-        help=("Save the validation report to a file, not print to the console."),
+        help=("Save the validation log to a file, not print to the console."),
+    )
+
+    parser.add_argument(
+        "-j",
+        "--json",
+        default=None,
+        type=Path,
+        help=("An optional output path for the validated dataset JSON."),
     )
 
     parser.add_argument(
@@ -151,10 +165,10 @@ def _safedata_validator_cli(args_list: Optional[list[str]] = None) -> int:
     args = parser.parse_args(args=args_list)
 
     # Configure the logging location
-    if args.output is None:
+    if args.log is None:
         use_stream_logging()
     else:
-        use_file_logging(args.output)
+        use_file_logging(args.log)
 
     # Create the dataset and load from workbook
     ds = Dataset(resources=Resources(args.resources))
@@ -168,15 +182,13 @@ def _safedata_validator_cli(args_list: Optional[list[str]] = None) -> int:
         sys.stdout.write("File validation failed\n")
         return 1
 
-    json_file = os.path.splitext(args.filename)[0] + ".json"
-
+    # Output JSON file
+    json_file = args.json or os.path.splitext(args.filename)[0] + ".json"
     with open(json_file, "w") as json_out:
         json_out.write(ds.to_json())
 
-    sys.stdout.write("------------------------\n")
     sys.stdout.write("File validation passed\n")
     sys.stdout.write(f"JSON metadata written to {json_file}\n")
-    sys.stdout.write("------------------------\n")
     return 0
 
 

--- a/safedata_validator/logger.py
+++ b/safedata_validator/logger.py
@@ -85,8 +85,6 @@ class StreamCounterHandler(logging.StreamHandler):
     def reset(self) -> None:
         """Reset the message counters to zero."""
         self.counters = {"DEBUG": 0, "INFO": 0, "WARNING": 0, "ERROR": 0, "CRITICAL": 0}
-        self.stream.seek(0)
-        self.stream.truncate(0)
 
 
 class FileCounterHandler(logging.FileHandler):

--- a/test/test_entry_points.py
+++ b/test/test_entry_points.py
@@ -39,7 +39,7 @@ def test_entry_points_run(entry_point):
 @pytest.mark.parametrize(
     argnames="entry_point",
     argvalues=[
-        "_safedata_validator_cli",
+        "_safedata_validate_cli",
         "_safedata_zenodo_cli",
         "_safedata_metadata_cli",
         "_build_local_gbif_cli",
@@ -92,3 +92,23 @@ def test_sdv_zenodo_html_and_xml(user_config_file, command, file_exists, returns
     )
 
     assert value == returns
+
+
+def test_safedata_validate(user_config_file):
+    """Test the safedata_validate entry point works."""
+
+    from safedata_validator.entry_points import _safedata_validate_cli
+
+    # Need to create fake files to be used for the validation outputs
+    user_config_file.create_file("/tmp/validation_log.txt")
+    user_config_file.create_file("/tmp/validation_report.json")
+
+    _ = _safedata_validate_cli(
+        args_list=[
+            "--log",
+            "/tmp/validation_log.txt",
+            "--json",
+            "/tmp/validation_report.json",
+            FIXTURE_FILES.rf.good_ncbi_file,
+        ]
+    )

--- a/test/test_entry_points.py
+++ b/test/test_entry_points.py
@@ -95,7 +95,11 @@ def test_sdv_zenodo_html_and_xml(user_config_file, command, file_exists, returns
 
 
 def test_safedata_validate(user_config_file):
-    """Test the safedata_validate entry point works."""
+    """Test the safedata_validate entry point works via the arglist.
+
+    It would be neat to demonstrate that this works via subprocess as an actual CLI call
+    but subprocess and pyfakefs do not work together. This is the next best thing.
+    """
 
     from safedata_validator.entry_points import _safedata_validate_cli
 


### PR DESCRIPTION
This PR removes some code from the logger counter handler `reset` method to fix #113.

It also:

* Updates the `_safedata_validate_cli` entry point to allow the log and JSON outputs to take optional paths, partly to make it easier to test, partly to take away fixed paths.
* Uses that entry point with existing test fixture files to perform an actual test of the `safedata_validate` entry point.