### PR TITLE
Bugfix/summary whitespace

### DIFF
--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -306,20 +306,8 @@ class Summary:
         # continue processing.
         self._rows = {str(rw[0]).lower(): rw[1:] for rw in rows}
 
-        # Check if metadata field names have white space padding
-        clean_field_names = IsNotPadded(self._rows.keys())
-        if not clean_field_names:
-            # Report whitespace padding and clean up tuples
-            LOGGER.error(
-                "Whitespace padding in summary field names: ",
-                extra={"join": clean_field_names.failed},
-            )
-
-            # Order preserved in dict and validator
-            cleaned_entries = [
-                (ky, val) for ky, val in zip(clean_field_names, self._rows.values())
-            ]
-            self._rows = dict(cleaned_entries)
+        # Check if metadata keys have white space padding
+        self._check_for_whitespace()
 
         # Validate the keys found in the summary table
         self._validate_keys()
@@ -344,6 +332,27 @@ class Summary:
             LOGGER.info(f"Summary contains {self.n_errors} errors")
         else:
             LOGGER.info("Summary formatted correctly")
+
+    def _check_for_whitespace(self) -> None:
+        """Check that the summary keys do not have whitespace padding.
+
+        This function checks that the keys in a summary table do not have white space
+        padding, if they do the white space padding is removed and an error is logged.
+        """
+
+        clean_metadata_keys = IsNotPadded(self._rows.keys())
+        if not clean_metadata_keys:
+            # Report whitespace padding and clean up tuples
+            LOGGER.error(
+                "Whitespace padding in summary field names: ",
+                extra={"join": clean_metadata_keys.failed},
+            )
+
+            # Order preserved in dict and validator
+            cleaned_entries = [
+                (ky, val) for ky, val in zip(clean_metadata_keys, self._rows.values())
+            ]
+            self._rows = dict(cleaned_entries)
 
     def _validate_keys(self) -> None:
         """Validate the summary keys recovered.

--- a/test/test_summary.py
+++ b/test/test_summary.py
@@ -4,9 +4,7 @@ import datetime
 from logging import ERROR, INFO, WARNING
 
 import pytest
-from dotmap import DotMap
 from openpyxl import Workbook
-from sympy import Sum
 
 from safedata_validator.logger import LOGGER
 from safedata_validator.resources import Resources
@@ -1287,6 +1285,56 @@ def test_load_rows_from_worksheet(data, expected_rows):
 
     # Test parsed rows match what was expected
     assert rows == expected_rows
+
+
+@pytest.mark.parametrize(
+    argnames=["rows", "expected_log_entries"],
+    argvalues=[
+        pytest.param(
+            {
+                "title": [],
+                "description": [],
+                "access status": [],
+                "author name": [],
+                "keywords": [],
+            },
+            (),
+            id="good no padding",
+        ),
+        pytest.param(
+            {
+                "title ": [],
+                "description": [],
+                "access status": [],
+                "author name": [],
+                "keywords": [],
+            },
+            ((ERROR, "Whitespace padding in summary field names:"),),
+            id="padding after",
+        ),
+        pytest.param(
+            {
+                "title": [],
+                " description": [],
+                " access status": [],
+                "author name": [],
+                "keywords": [],
+            },
+            ((ERROR, "Whitespace padding in summary field names:"),),
+            id="padding before",
+        ),
+    ],
+)
+def test_check_for_whitespace(caplog, fixture_summary, rows, expected_log_entries):
+    """Test that function to check for whitespace padding in summary fields works."""
+
+    # Add rows to fixture
+    fixture_summary._rows = rows
+
+    # Check that row row headers contain mandatory fields
+    fixture_summary._check_for_whitespace()
+
+    log_check(caplog, expected_log_entries)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds an extra step to the `Summary.load` method that checks for whitespace padding. If any is found an informative error is raised and the padding is stripped so that validation can continue.


Fixes #126 