### PR TITLE
Switched example file download links to point to develop

### DIFF
--- a/docs/data_managers/overview.md
+++ b/docs/data_managers/overview.md
@@ -69,7 +69,7 @@ labels and headers, can be downloaded
 [here](https://github.com/ImperialCollegeLondon/safedata_validator/raw/main/docs/data_providers/data_format/Template.xlsx).
 An example dataset demonstrating how to correctly format a wide variety of different
 types of data can be downloaded
-[here](https://github.com/ImperialCollegeLondon/safedata_validator/raw/develop/docs/data_providers/data_format/Example.xlsx)
+[here](https://github.com/ImperialCollegeLondon/safedata_validator/raw/main/docs/data_providers/data_format/Example.xlsx)
 You can also look at existing published datasets, such as those from the SAFE Project,
 to see how the format is used:
 

--- a/docs/data_managers/overview.md
+++ b/docs/data_managers/overview.md
@@ -69,7 +69,7 @@ labels and headers, can be downloaded
 [here](https://github.com/ImperialCollegeLondon/safedata_validator/raw/main/docs/data_providers/data_format/Template.xlsx).
 An example dataset demonstrating how to correctly format a wide variety of different
 types of data can be downloaded
-[here](https://github.com/ImperialCollegeLondon/safedata_validator/raw/feature/example_file/docs/data_providers/data_format/Example.xlsx)
+[here](https://github.com/ImperialCollegeLondon/safedata_validator/raw/develop/docs/data_providers/data_format/Example.xlsx)
 You can also look at existing published datasets, such as those from the SAFE Project,
 to see how the format is used:
 

--- a/docs/data_providers/data_format/overview.md
+++ b/docs/data_providers/data_format/overview.md
@@ -47,7 +47,7 @@ A spreadsheet template containing the required worksheets, labels and headers ca
 downloaded
 [here.](https://github.com/ImperialCollegeLondon/safedata_validator/raw/main/docs/data_providers/data_format/Template.xlsx)
 
-There is also an example file, which can be downloaded [here.](https://github.com/ImperialCollegeLondon/safedata_validator/raw/develop/docs/data_providers/data_format/Example.xlsx)
+There is also an example file, which can be downloaded [here.](https://github.com/ImperialCollegeLondon/safedata_validator/raw/main/docs/data_providers/data_format/Example.xlsx)
 This file is intended to demonstrate how to correctly format a wide variety of different
 types of data. The data in this spreadsheet mirrors the example data showed later in
 this section of the documentation. We would strongly recommend reading the relevant

--- a/docs/data_providers/data_format/overview.md
+++ b/docs/data_providers/data_format/overview.md
@@ -47,7 +47,7 @@ A spreadsheet template containing the required worksheets, labels and headers ca
 downloaded
 [here.](https://github.com/ImperialCollegeLondon/safedata_validator/raw/main/docs/data_providers/data_format/Template.xlsx)
 
-There is also an example file, which can be downloaded [here.](https://github.com/ImperialCollegeLondon/safedata_validator/raw/feature/example_file/docs/data_providers/data_format/Example.xlsx)
+There is also an example file, which can be downloaded [here.](https://github.com/ImperialCollegeLondon/safedata_validator/raw/develop/docs/data_providers/data_format/Example.xlsx)
 This file is intended to demonstrate how to correctly format a wide variety of different
 types of data. The data in this spreadsheet mirrors the example data showed later in
 this section of the documentation. We would strongly recommend reading the relevant


### PR DESCRIPTION
This PR switches the download link to point to the `Example.xlsx` version stored in the `develop` branch (rather than my now deleted feature branch).

In future, this should probably point to `main` so that the contents of `Example.xlsx` can only change with a new release (this is making the assumption that people should only ever be using the most recent version of `safedata_validator` which is probably reasonable).