### PR TITLE
Make maximum embargo length configurable

### DIFF
--- a/docs/data_managers/install/configuration.md
+++ b/docs/data_managers/install/configuration.md
@@ -172,11 +172,11 @@ provided to validate datasets.
   dataset specific feature set in the [summary
   metadata](../../data_providers/data_format/summary.md#the-access-block).
 
-  Allowing reasonable embargo lengths is important to allow time for publications from
-  datasets, but equally setting very long embargo lengths makes it hard to re-use data.
-  It may be more appropriate to allow the use of the [`restricted`
-  access](../../data_providers/data_format/summary.md#the-access-block) option for a
-  subset of datasets than to globally allow very long embargo periods.
+    Allowing reasonable embargo lengths is important to allow time for publications from
+    datasets, but equally setting very long embargo lengths makes it hard to re-use data.
+    It may be more appropriate to allow the use of the [`restricted`
+    access](../../data_providers/data_format/summary.md#the-access-block) option for a
+    subset of datasets than to globally allow very long embargo periods.
 
 **The `extents` element**
 

--- a/docs/data_managers/install/configuration.md
+++ b/docs/data_managers/install/configuration.md
@@ -164,10 +164,19 @@ provided to validate datasets.
 
 **The `maximum_embargo_months` element**
 
-: Data providers can set an embargo date on their datasets. Once published, the metadata
-  for the dataset can be seen on Zenodo but the data itself cannot be downloaded until
-  after the embargo has expired. This configuration element sets the maximum number of
-  months allowed for this embargo period: it defaults to 24 months.
+: If a data provider submits a dataset with embargoed access, they must provide a date
+  for the end of the embargo period. This configuration element restricts the maximum
+  allowable length of the embargo period within a project, with a default of 24 months.
+  This setting is _only_ used to cause validation failures for datasets that request an
+  overlong embargo period. It does not apply embargo dates to datasets: this is always a
+  dataset specific feature set in the [summary
+  metadata](../../data_providers/data_format/summary.md#the-access-block).
+
+  Allowing reasonable embargo lengths is important to allow time for publications from
+  datasets, but equally setting very long embargo lengths makes it hard to re-use data.
+  It may be more appropriate to allow the use of the [`restricted`
+  access](../../data_providers/data_format/summary.md#the-access-block) option for a
+  subset of datasets than to globally allow very long embargo periods.
 
 **The `extents` element**
 

--- a/docs/data_managers/install/configuration.md
+++ b/docs/data_managers/install/configuration.md
@@ -15,6 +15,7 @@ ncbi_database = /path/to/local/ncbi_database.sqlite3
 gazetteer = /path/to/gazeteer.geojson
 location_aliases = /path/to/location_aliases.csv
 project_database = /path/to/project_database.csv
+maximum_embargo_months = 24
 
 [extents]
 temporal_soft_extent = 2002-02-02, 2030-01-31
@@ -160,6 +161,13 @@ provided to validate datasets.
         of whether or not to organise datasets into project. The data manager for a
         project will need to make this decision during the initial configuration of a
         data system.
+
+**The `maximum_embargo_months` element**
+
+: Data providers can set an embargo date on their datasets. Once published, the metadata
+  for the dataset can be seen on Zenodo but the data itself cannot be downloaded until
+  after the embargo has expired. This configuration element sets the maximum number of
+  months allowed for this embargo period: it defaults to 24 months.
 
 **The `extents` element**
 

--- a/docs/data_managers/using_safedata/posting_metadata.md
+++ b/docs/data_managers/using_safedata/posting_metadata.md
@@ -34,7 +34,7 @@ safedata_server post_metadata zenodo_1143714.json Example.json
 
 The metadata server is also used to distribute some of the validation resources used
 both `safedata_validator` and `safedata`, including the
-[gazetteer](../install/gazetteer.md) and the [Project ID
+[gazetteer](../install/gazetteer_files.md) and the [Project ID
 database](../install/configuration.md#validation-configuration). When you update these
 resources for validation locally, those new data also need to be posted to the metadata
 server. There are no command line arguments for this command - it simply updates the

--- a/docs/data_providers/availability.md
+++ b/docs/data_providers/availability.md
@@ -31,8 +31,9 @@ discussion.
 
 Restricted datasets must provide a set of access conditions, which will be visible on
 Zenodo along with the dataset metadata. Zenodo provides a link to request access to
-restricted datasets: these will come first to your organisations data manager but they
-will then **always** contact the original data owners before permitting access.
+restricted datasets: these will come first to your organisation's data manager, but the
+organisational policy will then likely be to **always** contact the original data owners
+before permitting access.
 
 ## Altering the access rights
 
@@ -53,9 +54,9 @@ This curation account for the collection is entirely separate from the authorshi
 ownership of datasets: **the citation for the data will always be to the original set of
 authors provided in the metadata.**
 
-Embargoed or restricted data will never be made available within the embargo period or
-without discussion with data authors. Data authors will always be consulted about issues
-arising with their datasets.
+Embargoed or restricted data should never be made available within the embargo period or
+without discussion with data authors. Data authors should always be consulted about
+issues arising with their datasets.
 
 !!! Note "`safedata` at the SAFE Project"
     For details of the SAFE project's data availability polices see

--- a/docs/data_providers/data_format/summary.md
+++ b/docs/data_providers/data_format/summary.md
@@ -102,7 +102,7 @@ single value for each field.
   be open access: see the [discussion of data availability](../availability.md).
 * **Embargo date**: If you choose embargoed access status then you must also
   enter the date when the embargo will end. This must be an Excel date formatted
-  value and you cannot embargo data for more than two years. Do not provide
+  value and your organisation will set a maximum embargo length. Do not provide
   access conditions: embargoed datasets become freely available when the embargo
   ends.
 * **Access conditions**: If you choose restricted access status then you must

--- a/docs/developers/api/taxa.md
+++ b/docs/developers/api/taxa.md
@@ -19,7 +19,6 @@
     options:
         show_root_heading: True
         header_level: 3
-        filters: ["!__del__"]
 
 ::: safedata_validator.taxa.GBIFError
     options:
@@ -37,7 +36,7 @@
     options:
         show_root_heading: True
         header_level: 3
-        filters: ["!__del__"]
+        members: True # Nuclear option to get private methods to show.
 
 ::: safedata_validator.taxa.NCBIError
     options:

--- a/safedata_validator/resources.py
+++ b/safedata_validator/resources.py
@@ -53,6 +53,7 @@ CONFIGSPEC = {
     "gbif_database": "string()",
     "ncbi_database": "string()",
     "project_database": "string(default=None)",
+    "maximum_embargo_months": "integer(default=24)",
     "extents": {
         "temporal_soft_extent": "date_list(min=2, max=2, default=None)",
         "temporal_hard_extent": "date_list(min=2, max=2, default=None)",
@@ -238,6 +239,7 @@ class Resources:
             if config_loaded.project_database == ""
             else config_loaded.project_database
         )
+        self.maximum_embargo_months = config_loaded.maximum_embargo_months
         self.config_type = config_loaded.config_type
         self.config_source = config_loaded.config_source
 

--- a/safedata_validator/summary.py
+++ b/safedata_validator/summary.py
@@ -9,6 +9,7 @@ import re
 from dataclasses import dataclass
 
 import requests  # type: ignore
+from dateutil.relativedelta import relativedelta
 from openpyxl.worksheet.worksheet import Worksheet
 
 from safedata_validator.extent import Extent
@@ -83,6 +84,9 @@ class Summary:
     """
 
     def __init__(self, resources: Resources) -> None:
+        self.resources: Resources = resources
+        """The resources used to create the Summary object."""
+
         self.title: str
         """A string giving the dataset title."""
         self.description: str
@@ -798,12 +802,17 @@ class Summary:
                 if embargo_date is None:
                     LOGGER.error("Dataset embargoed but no embargo date provided")
                 elif isinstance(embargo_date, datetime.datetime):
+                    # Get the relevant test dates
                     now = datetime.datetime.now()
+                    maximum_embargo_date = now + relativedelta(
+                        months=self.resources.maximum_embargo_months
+                    )
 
+                    # Check the dates
                     if embargo_date < now:
                         LOGGER.error("Embargo date is in the past.")
-                    elif embargo_date > now + datetime.timedelta(days=2 * 365):
-                        LOGGER.error("Embargo date more than two years in the future.")
+                    elif embargo_date > maximum_embargo_date:
+                        LOGGER.error("Embargo date exceeds the maximum embargo length.")
                     else:
                         LOGGER.info(f"Dataset access: embargoed until {embargo_date}")
 

--- a/test/test_summary.py
+++ b/test/test_summary.py
@@ -212,7 +212,7 @@ def test_authors(caplog, fixture_summary, alterations, should_log_error, expecte
                 "access conditions": (None,),
             },
             True,
-            "Embargo date more than",
+            "Embargo date exceeds the maximum embargo length.",
         ),
         (
             {


### PR DESCRIPTION
This PR:

* Adds `maximum_embargo_months` to the configuration,
* Documents that option
* Implements using the option in checking the `embargo_date` field in the `Summary` worksheet.

It also fixes some doc build issues that I thought I'd already fixed.