### PR TITLE
Fix file synchronisation issue with new versions of embargoed datasets

### DIFF
--- a/safedata_validator/zenodo.py
+++ b/safedata_validator/zenodo.py
@@ -241,7 +241,7 @@ def create_deposit(
     # Create the draft
     create_response = ZenodoResponse(requests.post(api, params=zen_res.token, json={}))
 
-    # Return the reponse on failure or if the request is not for a new version
+    # Return the response on failure or if the request is not for a new version
     if not create_response.ok or new_version is None:
         return create_response
 
@@ -1016,7 +1016,10 @@ def publish_dataset(
         # when a version is requested and we need to get the most recent file listing to
         # update the files sanely.
         latest_version = ZenodoResponse(
-            requests.get(requested_version.json_data["links"]["latest"])
+            requests.get(
+                requested_version.json_data["links"]["latest"],
+                params=zen_res.token,
+            )
         )
 
         latest_id = latest_version.json_data["id"]
@@ -1031,8 +1034,8 @@ def publish_dataset(
         # allow for checking of files with identical name and content
         incoming_files = {(p.name, _compute_md5(p)) for p in paths_to_upload}
         existing_files = {
-            (p["key"], p["checksum"].removeprefix("md5:"))
-            for p in latest_version.json_data["files"]
+            (p["filename"], p["checksum"].removeprefix("md5:"))
+            for p in requested_version.json_data["files"]
         }
 
         # Split files into files to be upload, files to be deleted from deposit and


### PR DESCRIPTION
If the `publish_dataset` command line option is being used to create a new version of an existing dataset, then the workflow checks which files in the new payload are unchanged and so are already present online in the new version.

The `["files"]` entry in the JSON response is, however, only populated if the record is open _or_ the request is authenticated, so is not populated without authentication for embargoed and restricted deposits. That's a problem because the link given in `json_data["links"]["latest"]` deliberately redirects to the API record for that link and the `requests` package does not add the authentication parameters to the redirected URL. This is a big problem as the list of files is not returned so the process to check which files to re-upload breaks down.

To fix this we now use the list of files found previously using `get_deposit` to find `requested_version`. In this case the link does not redirect so the authentication problem does not occur. The existing checking that this requested version matches with the most recent version ensures that we are looking at the right deposit.

Fixes #185